### PR TITLE
Fixed ion_auth_model can't access ion_auth property when auto login.

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -103,6 +103,8 @@ class Ion_auth
 		//auto-login the user if they are remembered
 		if (!$this->logged_in() && get_cookie('identity') && get_cookie('remember_code'))
 		{
+			$CI = &get_instance();
+			$CI->ion_auth = $this;
 			$this->ci->ion_auth_model->login_remembered_user();
 		}
 	}


### PR DESCRIPTION
In the Ion_auth class' __construct function, it load the ion_auth_model, and then check the auto-login, when calling $this->ci->ion_auth_model->login_remembered_user(), the Ion_auth class were not finished init.

So, in the Ion_auth_model's login_remembered_user function, it can't using `$this->ion_auth`, the `ion_auth` property is null, on the line 965:

  if (isset($this->ion_auth->_extra_where))

This line may cause the issue.

Sorry for my English, hope this help.
