### PR TITLE
Fixed 'Object of class stdClass could not be converted to string' error on deactivate page.

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -243,7 +243,7 @@ class Auth extends Controller {
 		{
 			// insert csrf check
 			$this->data['csrf'] = $this->_get_csrf_nonce();
-			$this->data['user'] = $this->ion_auth->get_user($id);
+			$this->data['user'] = $this->ion_auth->get_user_array($id);
 			$this->load->view('auth/deactivate_user', $this->data);
 		}
 		else

--- a/views/auth/deactivate_user.php
+++ b/views/auth/deactivate_user.php
@@ -2,9 +2,9 @@
 
 	<div class="pageTitle">Deactivate User</div>
     <div class="pageTitleBorder"></div>
-	<p>Are you sure you want to deactivate the user '<?php echo $user->username; ?>'</p>
+	<p>Are you sure you want to deactivate the user '<?php echo $user['username']; ?>'</p>
 	
-    <?php echo form_open("auth/deactivate/".$user->id);?>
+    <?php echo form_open("auth/deactivate/".$user['id']);?>
     	
       <p>
       	<label for="confirm">Yes:</label>
@@ -14,7 +14,7 @@
       </p>
       
       <?php echo form_hidden($csrf); ?>
-      <?php echo form_hidden(array('id'=>$user->id)); ?>
+      <?php echo form_hidden(array('id'=>$user['id'])); ?>
       
       <p><?php echo form_submit('submit', 'Submit');?></p>
 


### PR DESCRIPTION
Consistently got an error on the deactivate page that just read 'Object of class stdClass could not be converted to string'. This fixes that.
