### PR TITLE
Free db result on row() and row_array().

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -761,14 +761,20 @@ class Ion_auth_model extends CI_Model
 	{
 		$this->trigger_events('row');
 		
-		return $this->response->row();
+		$row = $this->response->row();
+		$this->response->free_result();
+		
+		return $row;
 	}
 
 	public function row_array()
 	{
 		$this->trigger_events(array('row', 'row_array'));
 		
-		return $this->response->row_array();
+		$row = $this->response->row_array();
+		$this->response->free_result();
+		
+		return $row;
 	}
 
 	public function result()


### PR DESCRIPTION
I'm having some weird issues with multiple calls to `$this->ion_auth->user($id)` mixing up with each other. For example, say you have:
1. Joe Blow
2. Jane Blow
3. Jimmy Blow

If you call `$joe = $this->ion_auth->user(1)->row()` you'll get the correct result, but if you call `$jane = $this->ion_auth->user(2)->row()` or `$jimmy = $this->ion_auth->user(3)->row()` any time thereafter you'll end up with the first result.

This could be bad understanding/programming on my part (most likely) or some unforseen bugs in IO2.
