### PR TITLE
in_group always returned TRUE. Introduced in d0bc61631d918b2ce530

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -351,7 +351,6 @@ class Ion_auth
 			$groups[] = $group->name;
 		}
 		
-		
 		if (is_array($check_group)) 
 		{
 			foreach($check_group as $key => $value)
@@ -370,7 +369,7 @@ class Ion_auth
 			}
 		}
 		
-		return TRUE;
+		return FALSE;
 	}
 
 


### PR DESCRIPTION
Took me half an hour to figure out why I was all of a sudden in every group I checked users against...LOL.
