### PR TITLE
Possible SQL error in ion_auth.sql

### DIFF
--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -53,7 +53,7 @@ CREATE TABLE `users` (
 # Dumping data for table 'users'
 #
 
-INSERT INTO `users` (`id`, `ip_address`, `username`, `password`, `salt`, `email`, `activation_code`, `forgotten_password_code`, `created_on`, `last_login`, `active`, `first_name`, `last_name`, `company`, `phone`) VALUES
+INSERT INTO `users` (`group_id`, `ip_address`, `username`, `password`, `salt`, `email`, `activation_code`, `forgotten_password_code`, `created_on`, `last_login`, `active`, `first_name`, `last_name`, `company`, `phone`) VALUES
 	('1',INET_ATON('127.0.0.1'),'administrator','59beecdf7fc966e2f17fd8f65a4a9aeb09d4a3d4','9462e8eee0','admin@admin.com','',NULL,'1268889823','1268889823','1', 'Admin','istrator','ADMIN','0');
 
 


### PR DESCRIPTION
I think group_id and not id is the correct insert field for line 56.  Otherwise MySQL responds with "no default value for group_id" error.
