### PR TITLE
Revise ion_auth.sql so that users_groups column types match ids for users

### DIFF
--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -64,8 +64,8 @@ DROP TABLE IF EXISTS `users_groups`;
 
 CREATE TABLE `users_groups` (
   `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `user_id` mediumint(8) NOT NULL,
-  `group_id` mediumint(8) NOT NULL,
+  `user_id` mediumint(8) unsigned NOT NULL,
+  `group_id` mediumint(8) unsigned NOT NULL,
   PRIMARY KEY (`id`)
 );
 


### PR DESCRIPTION
Minor change, revise ion_auth.sql so that users_groups column types match ids for users and groups tables.

Id columns for users and groups tables were mediumint(8) unsigned NOT NULL.

users_groups table has user_id/group_id were mediumint(8) NOT NULL.

You can't make an InnoDB foreign key between these tables unless the column types are identical. Changed users_groups to mediumint(8) unsigned NOT NULL.
