### PR TITLE
Fix update method so all columns can be updated 

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -998,11 +998,11 @@ class Ion_auth_model extends CI_Model
 			{
 				$data['password'] = $this->hash_password($data['password'], $user->salt);
 			}
-
-			$this->trigger_events('extra_where');
-
-			$this->db->update($this->tables['users'], $data, array('id' => $user->id));
 	    }
+
+	    $this->trigger_events('extra_where');
+	    $this->db->update($this->tables['users'], $data, array('id' => $user->id));
+
 
 	    if ($this->db->trans_status() === FALSE)
 	    {


### PR DESCRIPTION
In the current version, update() only works for the columns username, password, and email because the update call was wrapped within the if statement checking for those keys; the reason for checking for the password key is very obvious, I assume you mean to do something else with the other keys but I don't know what.

I've moved the trigger_events() call and the db->update() call outside the conditional so it will fire in other cases.
