### PR TITLE
Edited in_group function to optionally accept a user ID, so that the func

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -340,11 +340,11 @@ class Ion_auth
 	 * @return bool
 	 * @author Phil Sturgeon
 	 **/
-	public function in_group($check_group)
+	public function in_group($check_group, $id=false)
 	{
 		$this->ci->ion_auth_model->trigger_events('in_group');
 
-		$users_groups = $this->ci->ion_auth_model->get_users_groups();
+		$users_groups = $this->ci->ion_auth_model->get_users_groups($id);
 		$groups = array();
 		foreach ($users_groups as $group)
 		{


### PR DESCRIPTION
Currently, the in_group function can on check whether the currently logged in user is a member of a group.

I edited in_group function to optionally accept a user ID, so that the function can check to see if any user is a member of a group.

The ion_auth_model->get_users_groups function already accepts $id as an optional parameter.
