### PR TITLE
Used $config['tables']['users']

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -612,7 +612,7 @@ class Ion_auth_model extends CI_Model
 
 		//filter out any data passed that doesnt have a matching column in the users table
 		//and merge the set user data and the additional data
-		$user_data = array_merge($this->_filter_data('users', $additional_data), $data);
+		$user_data = array_merge($this->_filter_data($this->tables['users'], $additional_data), $data);
 	    
 	    $this->trigger_events('extra_set');
 


### PR DESCRIPTION
Please use the $config['tables']['users'] instead a hard coded table name 'users'.
