### PR TITLE
Fix: $this->ion_auth->current()->row()  ---> $this->ion_auth->user()->row

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -118,7 +118,7 @@ class Auth extends Controller {
 			redirect('auth/login', 'refresh');
 		}
 		
-		$user = $this->ion_auth->current()->row();
+		$user = $this->ion_auth->user()->row();
 
 		if ($this->form_validation->run() == false)
 		{ //display the form


### PR DESCRIPTION
Fix: $this->ion_auth->current()->row()  ---> $this->ion_auth->user()->row(), since current() is deprecated since commit https://github.com/benedmunds/CodeIgniter-Ion-Auth/commit/ef733edb5ef396fec57fe363c5c8616506054c79
