### PR TITLE
Updated: config/ion_auth.php

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -45,18 +45,12 @@
 	$config['admin_group']         = 'admin';
 	 
 	/**
-	 * Meta table column and Group table column you want to join WITH.
+	 * Users table column and Group table column you want to join WITH.
 	 * Joins from users.id
 	 * Joins from groups.id
 	 **/
 	$config['join']['users']       = 'user_id';
 	$config['join']['groups']      = 'group_id';
-	
-	/**
-	 * Columns in your meta table,
-	 * id not required.
-	 **/
-	$config['columns']             = array('first_name', 'last_name', 'company', 'phone');
 	
 	/**
 	 * A database column which is used to


### PR DESCRIPTION
-"Meta table"  --> "Users table" is a _wild_ guess, please review before accepting.

-$config['columns'] appears to be unused throughout the code?

In Bash:

find . ! -path "_userguide_" -type f | xargs grep -i -n --color=auto "columns"

Reveals no usage of $config['columns'].
