### PR TITLE
cache user groups to prevent multiple sql queries

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -48,6 +48,13 @@ class Ion_auth
 	 * @var array
 	 **/
 	public $_extra_set = array();
+	
+	/**
+	 * user groups
+	 * 
+	 * @var array
+	 */
+	private $_groups = NULL;
 
 	/**
 	 * __construct
@@ -342,10 +349,16 @@ class Ion_auth
 	public function in_group($check_group, $id=false)
 	{
 		$this->ci->ion_auth_model->trigger_events('in_group');
+		
+		if (!$this->_groups)
+		{
+			$this->_groups = array();
 
-		$users_groups = $this->ci->ion_auth_model->get_users_groups($id)->result();
+			$this->_groups = $this->ci->ion_auth_model->get_users_groups($id)->result();
+		}
+		
 		$groups = array();
-		foreach ($users_groups as $group)
+		foreach ($this->_groups as $group)
 		{
 			$groups[] = $group->name;
 		}


### PR DESCRIPTION
add $_groups cache that prevents multiple sql lookups for every $this->ion_auth->in_group($id) call
