### PR TITLE
Update libraries/Ion_auth.php

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -100,7 +100,7 @@ class Ion_auth
 	 **/
 	public function forgotten_password($identity)    //changed $email to $identity
 	{
-		if ( $this->ci->ion_auth_model->forgotten_password($identity,$this->ci->config->item('identity', 'ion_auth')) )   //changed
+		if ( $this->ci->ion_auth_model->forgotten_password($identity) )   //changed
 		{
 			// Get user information
 			$user = $this->where($this->ci->config->item('identity', 'ion_auth'), $identity)->users()->row();  //changed to get_user_by_identity from email


### PR DESCRIPTION
This goes with my other patch, and sends the identity from config over to the forgot_password function in the model.  It also adds a test to make sure a user was selected from the database and returns the standard error if it does not.
