### PR TITLE
fixed a doc example ($this->ion_auth->user()->row())

### DIFF
--- a/userguide/index.html
+++ b/userguide/index.html
@@ -598,7 +598,7 @@ Documentation
 
 	<p><b>Usage</b></p>
 	<pre>
-		$user = $this->ion_auth->user();
+		$user = $this->ion_auth->user()->row();
 		echo $user->email;
 	</pre>
 	<br />


### PR DESCRIPTION
An example for user() in the documentation was the following:

$user = $this->ion_auth->user();
echo $user->email;

But this failed because it was not accessing the user values.
The fix is to change it to:

$user = $this->ion_auth->user()->row();
