### PR TITLE
Fixed assignment-equals to hash_method in conditionals

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -449,7 +449,7 @@ class Ion_auth_model extends CI_Model
 		$old         = $this->hash_password_db($result->id, $old);
 		$new         = $this->hash_password($new, $result->salt);
 
-		if ($this->hash_method = 'sha1' && $db_password === $old || $this->hash_method = 'bcrypt' && $old === TRUE)
+		if ($this->hash_method == 'sha1' && $db_password === $old || $this->hash_method == 'bcrypt' && $old === TRUE)
 		{
 			//store the new password and reset the remember code so all remembered instances have to re-login
 			$data = array(
@@ -728,7 +728,7 @@ class Ion_auth_model extends CI_Model
 		{
 			$password = $this->hash_password_db($user->id, $password);
 
-			if ($this->hash_method = 'sha1' && $user->password === $password || $this->hash_method = 'bcrypt' && $password === true)
+			if ($this->hash_method == 'sha1' && $user->password === $password || $this->hash_method == 'bcrypt' && $password === true)
 			{
                 if ($user->active == 0)
                 {


### PR DESCRIPTION
I'm assuming these checks of hash_method are not supposed to be assignment operators. Just a small change, but it might lead to some irritating bugs.
