### PR TITLE
reset_password should not send users a plain text password by email

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -223,6 +223,32 @@ class Ion_auth
 	}
 
 	/**
+	 * forgotten_password_check
+	 *
+	 * @return void
+	 * @author Michael
+	 **/
+	public function forgotten_password_check($code)
+	{
+		$this->ci->ion_auth_model->trigger_events('pre_password_change');
+
+		$profile  = $this->where('forgotten_password_code', $code)->users()->row(); //pass the code to profile
+
+		if (!is_object($profile))
+		{
+			$this->ci->ion_auth_model->trigger_events(array('post_password_change', 'password_change_unsuccessful'));
+			$this->set_error('password_change_unsuccessful');
+			return FALSE;
+		}
+		else
+		{
+			$this->set_message('password_change_successful');
+			$this->ci->ion_auth_model->trigger_events(array('post_password_change', 'password_change_successful'));
+			return $profile;
+		}
+	}
+
+	/**
 	 * register
 	 *
 	 * @return void

--- a/views/auth/reset_password.php
+++ b/views/auth/reset_password.php
@@ -1,0 +1,19 @@
+<h1>Change Password</h1>
+
+<div id="infoMessage"><?php echo $message;?></div>
+
+<?php echo form_open('auth/reset_password/' . $code);?>
+      
+      <p>New Password (at least <?php echo $min_password_length;?> characters long):<br />
+      <?php echo form_input($new_password);?>
+      </p>
+      
+      <p>Confirm New Password:<br />
+      <?php echo form_input($new_password_confirm);?>
+      </p>
+      
+      <?php echo form_input($user_id);?>
+      <?php echo form_hidden($csrf); ?>
+      <p><?php echo form_submit('submit', 'Change');?></p>
+      
+<?php echo form_close();?>


### PR DESCRIPTION
Because the majority of users will not go to the trouble to change the randomly assigned password.

I changed the reset_password method on auth controller. It verifies the reset code using a new model function (forgotten_password_check), then shows a password reset form, which rechecks the reset code, the claimed user id, and a csrf field, before changing the password. If there are mismatches, it clears the forgot password code from the database.

With this change, the user only receives one email with a password reset link in it, and chooses the new password right away. I see you commented on this topic a couple of years ago here: http://codeigniter.com/forums/viewthread/154332/ but I wonder if the two-step process is still preferable. I can't recall ever seeing that type of process elsewhere.
