### PR TITLE
Recreate session on logout so flash messages are preserved

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -361,7 +361,9 @@ class Ion_auth
 			delete_cookie('remember_code');
 		}
 
+		//Recreate the session
 		$this->ci->session->sess_destroy();
+		$this->ci->session->sess_create();
 
 		$this->set_message('logout_successful');
 		return TRUE;


### PR DESCRIPTION
Currently when logout() is called, the session is destroyed, which means that subsequent uses of flash data will not work properly.

By creating a new session after the old one is destroyed, flash data that is set after logout() can be used to show the logout_successful message.
