### PR TITLE
Remove unneeded config option.

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -157,12 +157,7 @@
 	$config['email_config']         = array(
 		'mailtype' => 'html',
 	);
-
-	/**
-	 * Email content type
-	 **/
-	$config['email_type']           = 'html';
-
+	
 	/**
 	 * Folder where email templates are stored.
      * Default : auth/
@@ -170,7 +165,7 @@
 	$config['email_templates']     = 'auth/email/';
 	
 	/**
-	 * activate Account Email Template
+	 * Activate Account Email Template
      * Default : activate.tpl.php
 	 **/
 	$config['email_activate']   = 'activate.tpl.php';


### PR DESCRIPTION
Left over from commit f67492cb43cc1b4d95e4e238d9a42393225245d5.

Was also toying around with an easier way to set up the config options, but couldn't get it to keep me logged in. (It would run the login and set the session, but redirect me back to the login page like I was not logged in. This might have been because of that line removed in 9daf9be3317631d7faf8d829897f6ae828c8efca though.)
