### PR TITLE
Bcrypt initialization happens several times

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -179,6 +179,23 @@ class Ion_auth_model extends CI_Model
 		//initialize our hooks object
 		$this->_ion_hooks = new stdClass;
 
+		//load the bcrypt class if needed
+		if ($this->hash_method == 'bcrypt') {
+			if ($this->random_rounds)
+			{
+				$rand = rand($this->min_rounds,$this->max_rounds);
+				$rounds = array('rounds' => $rand);
+
+			}
+			else
+			{
+				$rounds = array('rounds' => $this->default_rounds);
+			}
+
+			$CI=& get_instance();
+			$CI->load->library('bcrypt',$rounds);
+		}
+		
 		$this->trigger_events('model_constructor');
 	}
 	
@@ -209,20 +226,7 @@ class Ion_auth_model extends CI_Model
 		//bcrypt
 		if ($use_sha1_override === FALSE && $this->hash_method == 'bcrypt')
 		{
-			
-			if ($this->random_rounds)
-			{
-				$rand = rand($this->min_rounds,$this->max_rounds);
-				$rounds = array('rounds' => $rand);
-				
-			}
-			else
-			{
-				$rounds = array('rounds' => $this->default_rounds);
-			}
-
 			$CI=& get_instance();
-			$CI->load->library('bcrypt',$rounds);
 			return $CI->bcrypt->hash($password);
 		}
 
@@ -270,8 +274,6 @@ class Ion_auth_model extends CI_Model
 	     if ($use_sha1_override === FALSE && $this->hash_method == 'bcrypt')
 		{
 			$CI=& get_instance();
-			$CI->load->library('bcrypt',null);
-			
 			if ($CI->bcrypt->verify($password,$hash_password_db->password))
 			{
 			 return TRUE;


### PR DESCRIPTION
The bcrypt library was being loaded in hash_password() and hash_password_db(). In hash_password(), it is used for creating new password hashes, so it is passed the $rounds parameter when initialized. In hash_password_db(), it is only used to verify the password, so it is not given the $rounds parameter.

However, during a password change, one first verifies the supplied old password, which requires a call to hash_password_db(), and then generates the new password hash via hash_password(). Since the bcrypt library was already loaded, hash_password() does not reload it with the $rounds parameter. New password hashes are thus always created with $rounds=7, regardless of the config setting.

I just moved the bcrypt loading into the constructor for the model (I'm still only loading it if the hash method is set to bcrypt).
