### PR TITLE
Support for IPv6 ip addresses

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -752,7 +752,7 @@ class Ion_auth_model extends CI_Model
 		}
 
 		// IP Address
-		$ip_address = inet_pton($this->input->ip_address());
+		$ip_address = $this->input->ip_address();
 		$salt       = $this->store_salt ? $this->salt() : FALSE;
 		$password   = $this->hash_password($password, $salt);
 

--- a/sql/ion_auth.mssql.sql
+++ b/sql/ion_auth.mssql.sql
@@ -1,6 +1,6 @@
 CREATE TABLE users (
     id int NOT NULL IDENTITY(1,1),
-    ip_address varbinary(16) NOT NULL,
+    ip_address varchar(40) NOT NULL,
     username varchar(100) NOT NULL,
     password varchar(40) NOT NULL,
     salt varchar(40),
@@ -50,7 +50,7 @@ SET IDENTITY_INSERT groups OFF;
 
 SET IDENTITY_INSERT users ON;
 INSERT INTO users (id, ip_address, username, password, salt, email, activation_code, forgotten_password_code, created_on, last_login, active, first_name, last_name, company, phone) 
-	VALUES ('1',0x7F000001,'administrator','59beecdf7fc966e2f17fd8f65a4a9aeb09d4a3d4','9462e8eee0','admin@admin.com','',NULL, GETDATE(), GETDATE(),'1','Admin','istrator','ADMIN','0'); 
+	VALUES ('1','127.0.0.1','administrator','59beecdf7fc966e2f17fd8f65a4a9aeb09d4a3d4','9462e8eee0','admin@admin.com','',NULL, GETDATE(), GETDATE(),'1','Admin','istrator','ADMIN','0'); 
 SET IDENTITY_INSERT users OFF;
 
 SET IDENTITY_INSERT users_groups ON;

--- a/sql/ion_auth.postgre.sql
+++ b/sql/ion_auth.postgre.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "users" (
     "id" SERIAL NOT NULL,
-    "ip_address" char(16) NOT NULL,
+    "ip_address" varchar(40) NOT NULL,
     "username" varchar(100) NOT NULL,
     "password" varchar(40) NOT NULL,
     "salt" varchar(40),

--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -29,7 +29,7 @@ DROP TABLE IF EXISTS `users`;
 
 CREATE TABLE `users` (
   `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `ip_address` varbinary(17) unsigned NOT NULL,
+  `ip_address` varchar(40) NOT NULL,
   `username` varchar(100) NOT NULL,
   `password` varchar(40) NOT NULL,
   `salt` varchar(40) DEFAULT NULL,
@@ -54,7 +54,7 @@ CREATE TABLE `users` (
 #
 
 INSERT INTO `users` (`id`, `ip_address`, `username`, `password`, `salt`, `email`, `activation_code`, `forgotten_password_code`, `created_on`, `last_login`, `active`, `first_name`, `last_name`, `company`, `phone`) VALUES
-	('1',INET_ATON('127.0.0.1'),'administrator','59beecdf7fc966e2f17fd8f65a4a9aeb09d4a3d4','9462e8eee0','admin@admin.com','',NULL,'1268889823','1268889823','1', 'Admin','istrator','ADMIN','0');
+	('1','127.0.0.1','administrator','59beecdf7fc966e2f17fd8f65a4a9aeb09d4a3d4','9462e8eee0','admin@admin.com','',NULL,'1268889823','1268889823','1', 'Admin','istrator','ADMIN','0');
 
 
 DROP TABLE IF EXISTS `users_groups`;


### PR DESCRIPTION
The model uses the inet_pton() function to compact ip addresses before inserting them in the database, which means it supports IPv6 addresses.

That said, I couldn't figure out how to store these values in PostgreSQL without code changes. They have a bytea format, but as far as I can tell it expects binary data in a special format. Couldn't test that though, only have MySQL. I think the SQL Server version is right though.

As an alternative, it could also work to just use varchars for ip addresses... a bit slower and bulkier but also friendlier and more portable.
