### PR TITLE
Hotfix/forgot password

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -486,7 +486,7 @@ class Ion_auth_model extends CI_Model
 			'password' => $new,
 			'remember_code' => NULL,
 			'forgotten_password_code' => NULL,
-			'active'                  => 1,
+			'forgotten_password_time' => NULL,
 			);
 
 		$this->trigger_events('extra_where');


### PR DESCRIPTION
- Add error checking to `reset_password()`
- Fix security issue with `reset_password()` activating an account
- Set `forgotten_password_time` to NULL when resetting password
- Remove password changing from `clear_forgotten_password_code()`

Commit be6458f should disappear from this pull request once #213 is accepted.
