### PR TITLE
Added unneeded hashing operation on login with nonexistent user

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -868,6 +868,9 @@ class Ion_auth_model extends CI_Model
 			}
 		}
 
+		//Hash something anyway, just to take up time
+		$this->hash_password($password);
+		
 		$this->increase_login_attempts($identity);
 		
 		$this->trigger_events('post_login_unsuccessful');


### PR DESCRIPTION
Currently, if a user submits an identity and password to the login form, and the identity is not in the database, the form returns an error immediately. If the identity is in the database, the supplied password is checked against the stored hash, which takes a fraction of a second longer.

However, the difference is noticeable (about 100ms on my machine, using bcrypt with 10 rounds), which means that it would be possible for someone to determine if an account exists by the amount of time it takes for the login form to be processed.

I added a call to hash_password to the login() method to make the processing time when the user doesn't exist more equitable.
