### PR TITLE
Limit not applied after group() and user() in model

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -1102,6 +1102,12 @@ class Ion_auth_model extends CI_Model
 			$this->_ion_limit  = NULL;
 			$this->_ion_offset = NULL;
 		}
+		else if (isset($this->_ion_limit)) 
+		{
+			$this->db->limit($this->_ion_limit);
+			
+			$this->_ion_limit  = NULL;
+		}
 
 		//set the order
 		if (isset($this->_ion_order_by) && isset($this->_ion_order))
@@ -1223,6 +1229,12 @@ class Ion_auth_model extends CI_Model
 
 			$this->_ion_limit  = NULL;
 			$this->_ion_offset = NULL;
+		}
+		else if (isset($this->_ion_limit)) 
+		{
+			$this->db->limit($this->_ion_limit);
+			
+			$this->_ion_limit  = NULL;
 		}
 
 		//set the order


### PR DESCRIPTION
If you just call group() or user() on the model, a limit is applied, but the offset is not set. Then, in groups() or users(), respectively, the limit is only applied if _both_ the limit and offset are set.

I added new conditions to users() and groups() to handle this case.
