### PR TITLE
Optimize default group logic for registration.

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -185,7 +185,6 @@ class Ion_auth_model extends CI_Model
 			{
 				$rand = rand($this->min_rounds,$this->max_rounds);
 				$rounds = array('rounds' => $rand);
-
 			}
 			else
 			{
@@ -696,7 +695,7 @@ class Ion_auth_model extends CI_Model
 					return FALSE;
 				}
 			}
-            
+			
 			$password = $this->salt();
 
 			$data = array(
@@ -793,7 +792,7 @@ class Ion_auth_model extends CI_Model
 
 		//add to default group if not already set
 		$default_group = $this->where('name', $this->config->item('default_group', 'ion_auth'))->group()->row();
-		if (isset($default_group->id) && isset($groups) && !empty($groups) && !in_array($default_group->id, $groups) || !isset($groups) || empty($groups))
+		if ((isset($default_group->id) && !isset($groups)) || (empty($groups) && !in_array($default_group->id, $groups)))
 		{
 			$this->add_to_group($default_group->id, $id);
 		}


### PR DESCRIPTION
I'm not sure if that was the intended behavior or not. Based on the following cases, it didn't seem to make sense.

Registering new user, no groups set. Should be true. (Add the user to the default group.)

``` php
<?php
$default_group = new stdClass;
$default_group->id = 50;
$groups = array();
//old
var_dump(isset($default_group->id) && isset($groups) && !empty($groups) && !in_array($default_group->id, $groups) || !isset($groups) || empty($groups));
//new
var_dump((isset($default_group->id) && !isset($groups)) || (empty($groups) && !in_array($default_group->id, $groups)));
```

Result: http://codepad.org/FBdqywDX#output

Registering new user, group set to default group. Should be false. (Default group provided, don't need to do it twice.)

``` php
<?php
$default_group = new stdClass;
$default_group->id = 50;
$groups = array(50);
//old
var_dump(isset($default_group->id) && isset($groups) && !empty($groups) && !in_array($default_group->id, $groups) || !isset($groups) || empty($groups));
//new
var_dump((isset($default_group->id) && !isset($groups)) || (empty($groups) && !in_array($default_group->id, $groups)));
```

Result: http://codepad.org/KOxMa0cW#output

Registering new user, group set - NOT to the default. Should be false. (Supplying a different group from the default.) //Here's where it's a bit muddy. The old way adds the user to the group supplied as well as the default group. Intended behavior?

``` php
<?php
$default_group = new stdClass;
$default_group->id = 50;
$groups = array(10);
//old
var_dump(isset($default_group->id) && isset($groups) && !empty($groups) && !in_array($default_group->id, $groups) || !isset($groups) || empty($groups));
//new
var_dump((isset($default_group->id) && !isset($groups)) || (empty($groups) && !in_array($default_group->id, $groups)));
```

Result: http://codepad.org/Bl0Q7KP1#output
