### PR TITLE
Fixed hash_password_db

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -841,7 +841,7 @@ class Ion_auth_model extends CI_Model
 			
 			$password = $this->hash_password_db($user->id, $password);
 
-			if ($password === true)
+			if ($password === TRUE)
 			{
                 if ($user->active == 0)
                 {


### PR DESCRIPTION
Fixed hash_password_db to return true of false for SHA1 encryption instead of the encrypted password specified in the parameters.
