### PR TITLE
Unnecessary entry into users_groups table - there's no user 2, but a group is assigned on creation

### DIFF
--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -72,7 +72,6 @@ CREATE TABLE `users_groups` (
 
 INSERT INTO `users_groups` (`id`, `user_id`, `group_id`) VALUES
 	(1,1,1),
-	(2,1,2);
 
 
 DROP TABLE IF EXISTS `login_attempts`;


### PR DESCRIPTION
I know this is a one line pull request, and I'm sorry if this is unwarranted. I just feel simpler pull requests = lesser headache to check and approve. If I'm wrong, please tell me, and I'll send more substantial ones from next time. Thanks :)
