### PR TITLE
unnecessary additional entry into the users_groups table being made

### DIFF
--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -72,7 +72,6 @@ CREATE TABLE `users_groups` (
 
 INSERT INTO `users_groups` (`id`, `user_id`, `group_id`) VALUES
 	(1,1,1),
-	(2,1,2);
 
 
 DROP TABLE IF EXISTS `login_attempts`;


### PR DESCRIPTION
There is no user with ID 2, but he is being added to the "general user" group directly on install.

Is it okay to submit one-line pull requests? I'm slightly apprehensive of this, but I don't know, it might be easier for you to accept because it's a simple change :)
