### PR TITLE
get_users_groups() always returns the first group document

### DIFF
--- a/models/ion_auth_mongodb_model.php
+++ b/models/ion_auth_mongodb_model.php
@@ -1345,7 +1345,7 @@ class Ion_auth_mongodb_model extends CI_Model {
 		$user = (object) $user[0];
 		foreach ($user->groups as $group_id)
 		{
-			$groups[] = $this->group($group_id)->document();
+			$groups[] = $this->where('_id', new MongoId($group_id))->group()->document();
 		}
 
 		$this->response = $groups;
@@ -1463,12 +1463,11 @@ class Ion_auth_mongodb_model extends CI_Model {
 	 *
 	 * @return object
 	 */
-	public function group($id)
+	public function group()
 	{
 		$this->trigger_events('group');
 
 		// Set query parameters
-		$this->where('_id', new MongoId($id));
 		$this->limit(1);
 
 		// Execute and return results


### PR DESCRIPTION
There were an issue in the MongoDB model, this pull request should address this:  

The function `get_users_groups` always returns the first document in the groups collection, we were not passing the group `_id` !

Plus: MongoDB model duplicates document's object `_id` property into a fake `id` property to keep the API of both models identical to each other. But for better readability we should use `_id` internally.
