### PR TITLE
Fix mongodb model to not to invoke db driver

### DIFF
--- a/models/ion_auth_mongodb_model.php
+++ b/models/ion_auth_mongodb_model.php
@@ -162,7 +162,7 @@ class Ion_auth_mongodb_model extends CI_Model {
 	public function __construct()
 	{
 		parent::__construct();
-		$this->load->database();
+		$this->load->library('mongo_db');
 		$this->load->config('ion_auth', TRUE);
 		$this->load->helper('cookie');
 		$this->load->helper('date');


### PR DESCRIPTION
MongoDB model's constructor is always invoking database driver which is useless and not necessary at all. This pull request should address the issue. 
