### PR TITLE
set_newline was removed at some point, it is added back in when sending ...

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -383,7 +383,6 @@ class Ion_auth
 
 		//Recreate the session
 		$this->session->sess_destroy();
-		$this->session->sess_create();
 
 		$this->set_message('logout_successful');
 		return TRUE;


### PR DESCRIPTION
651c21f:
When I tested the latest version, I noticed that when I tried to reset my password, the page would hang up when trying to send the email.

I needed to add back $this->email->set_newline("\r\n");
This is in an older version but for some reason it was removed at some point

8ea6756
In the logout function, $this->session->sess_create() is being called after $this->session->sess_destroy();

If you call $this->session->set_flashdata('someKey', 'someValue'); right before calling the logout function, such as in the case of resetting the user password, then a 502 error is thrown.

In older versions sess_create() was not in the logout function
