### PR TITLE
use redirect("/", 'refresh') instead redirect($this->config->item('base_...

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -31,7 +31,7 @@ class Auth extends CI_Controller {
 		elseif (!$this->ion_auth->is_admin())
 		{
 			//redirect them to the home page because they must be an administrator to view this
-			redirect($this->config->item('base_url'), 'refresh');
+			redirect('/', 'refresh');
 		}
 		else
 		{
@@ -70,7 +70,7 @@ class Auth extends CI_Controller {
 				//if the login is successful
 				//redirect them back to the home page
 				$this->session->set_flashdata('message', $this->ion_auth->messages());
-				redirect($this->config->item('base_url'), 'refresh');
+				redirect('/', 'refresh');
 			}
 			else
 			{ 


### PR DESCRIPTION
...url'), 'refresh');

The correct way to redirect to the home page is 
redirect('/', 'refresh')

using 
redirect($this->config->item('base_url'), 'refresh')
works only if your base url is "". If your base_url is "example", you will be
redirect to http://www.yoursite.com/example/example producing an error

you need to replace all redirect($this->config->item('base_url'), 'refresh')
with redirect('/', 'refresh')
