### PR TITLE
Extend password fields from varchar(40) to varchar(80) 

### DIFF
--- a/sql/ion_auth.mssql.sql
+++ b/sql/ion_auth.mssql.sql
@@ -2,7 +2,7 @@ CREATE TABLE users (
     id int NOT NULL IDENTITY(1,1),
     ip_address varbinary(16) NOT NULL,
     username varchar(100) NOT NULL,
-    password varchar(40) NOT NULL,
+    password varchar(80) NOT NULL,
     salt varchar(40),
     email varchar(100) NOT NULL,
     activation_code varchar(40),

--- a/sql/ion_auth.postgre.sql
+++ b/sql/ion_auth.postgre.sql
@@ -2,7 +2,7 @@ CREATE TABLE "users" (
     "id" SERIAL NOT NULL,
     "ip_address" inet NOT NULL,
     "username" varchar(100) NOT NULL,
-    "password" varchar(40) NOT NULL,
+    "password" varchar(80) NOT NULL,
     "salt" varchar(40),
     "email" varchar(100) NOT NULL,
     "activation_code" varchar(40),

--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -31,7 +31,7 @@ CREATE TABLE `users` (
   `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
   `ip_address` varbinary(16) NOT NULL,
   `username` varchar(100) NOT NULL,
-  `password` varchar(40) NOT NULL,
+  `password` varchar(80) NOT NULL,
   `salt` varchar(40) DEFAULT NULL,
   `email` varchar(100) NOT NULL,
   `activation_code` varchar(40) DEFAULT NULL,


### PR DESCRIPTION
Extend password fields in sql files to varchar(80)
So no database changes are required if using bcrypt
