### PR TITLE
Error suppressor @ added libraries/Bcrypt.php:51

### DIFF
--- a/libraries/Bcrypt.php
+++ b/libraries/Bcrypt.php
@@ -48,7 +48,7 @@ class Bcrypt {
       $bytes = openssl_random_pseudo_bytes($count);
     }
 
-    if($bytes === '' && is_readable('/dev/urandom') &&
+    if($bytes === '' && @is_readable('/dev/urandom') &&
        ($hRand = @fopen('/dev/urandom', 'rb')) !== FALSE) {
       $bytes = fread($hRand, $count);
       fclose($hRand);


### PR DESCRIPTION
is_readable('/dev/urandom') will generate a PHP warning if it's not accessible to the current user. Causes CodeIgniter to halt output. /dev/urandom will not be readable in situations where an open_basedir restriction is in effect. This is very common on shared hosting. Errors from @fopen() are already suppressed in the same expression on line 52. Suppressing errors on is_readable() allows CodeIgniter to continue and use the fallback random generator correctly. I believe this is also a problem with phpass.  
New to github so hope I've done this correctly.
