### PR TITLE
Cache users groups on demand to prevent multiple sql queries 

### DIFF
--- a/models/ion_auth_mongodb_model.php
+++ b/models/ion_auth_mongodb_model.php
@@ -154,6 +154,20 @@ class Ion_auth_mongodb_model extends CI_Model {
 	 */
 	protected $error_end_delimiter;
 
+	/**
+	 * caching of users and their groups
+	 *
+	 * @var array
+	 */
+	public $_cache_user_in_group = array();
+
+	/**
+	 * caching of groups
+	 * 
+	 * @var array
+	 */
+	protected $_cache_groups = array();
+
 	// ------------------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
Several calls to `in_group()` don't query the database several times anymore.
Added a on-demand cache of users_groups that looks like this:
`[user_id] => array( [group_id] => [group_name], [group2_id] => [group2_name] )`

As a new query was added on `add_to_group()`, on-demand caching of groups was added too. (note: only `[group_id] => [group_name]`).

Fixes #307
