### PR TITLE
Implemented Temporary Lockout

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -95,6 +95,7 @@ $config['user_expire']          = 86500; 				// How long to remember the user (s
 $config['user_extend_on_login'] = FALSE; 				// Extend the users cookies everytime they auto-login
 $config['track_login_attempts'] = FALSE;				// Track the number of failed login attempts for each user or ip.
 $config['maximum_login_attempts']     = 3; 				// The maximum number of failed login attempts.
+$config['lockout_time'] = 600;				   			// The number of seconds to lockout an account due to exceeded attempts
 $config['forgot_password_expiration'] = 0; 				// The number of seconds after which a forgot password request will expire. If set to 0, forgot password requests will not expire.
 
 

--- a/language/english/ion_auth_lang.php
+++ b/language/english/ion_auth_lang.php
@@ -38,6 +38,7 @@ $lang['activation_email_unsuccessful']   	 = 'Unable to Send Activation Email';
 $lang['login_successful'] 		  	         = 'Logged In Successfully';
 $lang['login_unsuccessful'] 		  	     = 'Incorrect Login';
 $lang['login_unsuccessful_not_active'] 		 = 'Account is inactive';
+$lang['login_timeout']                       = 'Temporarily Locked Out.  Try again later.';
 $lang['logout_successful'] 		 	         = 'Logged Out Successfully';
 
 // Account Changes


### PR DESCRIPTION
Added feature to lock out an identity for a number of seconds if they
exceeded the maximum login attempts.  It has it's own custom warning in
the english language file, but it needs to be added to the other
languages as well.
