### PR TITLE
Don't required $id at edit_user() but...

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -483,11 +483,11 @@ class Auth extends CI_Controller {
 	}
 
 	//edit a user
-	function edit_user($id)
+	function edit_user($id = NULL)
 	{
 		$this->data['title'] = "Edit User";
 
-		if (!$this->ion_auth->logged_in() || !$this->ion_auth->is_admin())
+		if (!$id || !$this->ion_auth->logged_in() || !$this->ion_auth->is_admin())
 		{
 			redirect('auth', 'refresh');
 		}


### PR DESCRIPTION
Don't required $id at edit_user() but if it don't have redirect to the main page. This change is to avoid errors and the isnt passed.
