### PR TITLE
Updated misguided docs for users()

### DIFF
--- a/userguide/index.html
+++ b/userguide/index.html
@@ -760,12 +760,12 @@ Documentation
 
 	<p><strong>Return</strong></p>
 	<ul>
-		<li>array of objects</li>
+		<li>model object</li>
 	</ul>
 
 	<p><b>Usage</b></p>
 	<pre>
-		$users = $this->ion_auth->users();
+		$users = $this->ion_auth->users()->result();
 	</pre>
 	<br />
 


### PR DESCRIPTION
Hi Ben,

just made a minor change in the docs for users(), as it did not return an array of users as I expected while reading the docs.
