### PR TITLE
Added check_all param to in_group

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -458,10 +458,14 @@ class Ion_auth
 	/**
 	 * in_group
 	 *
+	 * @param mixed group(s) to check
+	 * @param bool user id
+	 * @param bool check if all groups is present, or any of the groups
+	 *
 	 * @return bool
 	 * @author Phil Sturgeon
 	 **/
-	public function in_group($check_group, $id=false)
+	public function in_group($check_group, $id=false, $check_all = false)
 	{
 		$this->ion_auth_model->trigger_events('in_group');
 
@@ -490,13 +494,25 @@ class Ion_auth
 		{
 			$groups = (is_string($value)) ? $groups_array : array_keys($groups_array);
 
-			if (in_array($value, $groups))
+			/**
+			 * if !all (default), in_array
+			 * if all, !in_array
+			 */
+			if (in_array($value, $groups) xor $check_all)
 			{
-				return TRUE;
+				/**
+				 * if !all (default), true
+				 * if all, false
+				 */
+				return !$check_all;
 			}
 		}
 
-		return FALSE;
+		/**
+		 * if !all (default), false
+		 * if all, true
+		 */
+		return $check_all;
 	}
 
 }

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -474,17 +474,18 @@ Documentation
 
 	<a name="in_group"></a>
 	<h2>in_group()</h2>
-	<p>Check to see if the currently logged in user is in the passed in group.</p>
+	<p>Check to see if the currently logged in user is in the passed group(s).</p>
 
 	<p><strong>Parameters</strong></p>
 	<ol>
-		<li>'Group ID or Name' - string, integer or array of strings and integers REQUIRED.</li>
+		<li>'Group ID or Name' - string REQUIRED. Integer or array of strings and integers.</li>
 		<li>'User ID' - integer OPTIONAL.  If a user id is not passed the id of the currently logged in user will be used.</li>
+		<li>'Check All' - bool OPTIONAL. Whether to check if user is in all groups, or in any group.</li>
 	</ol>
 
 	<p><strong>Return</strong></p>
 	<ul>
-		<li>boolean.  TRUE if the user is in any of the given groups, FALSE otherwise.</li>
+		<li>boolean.  TRUE if the user is in all or any (based on passed param), FALSE otherwise.</li>
 	</ul>
 
 	<p><b>Usage</b></p>
@@ -525,6 +526,14 @@ Documentation
 			$this->session->set_flashdata('message', 'You must be a part of the gangstas or group 2');
 			redirect('welcome/index');
 		}
+
+		# multiple groups (by id) and check if all exist
+		$group = array(1, 2);
+		if (!$this->ion_auth->in_group($group, false, true))
+			$this->session->set_flashdata('message', 'You must be a part of group 1 and 2 to view this page');
+			redirect('welcome/index');
+		}
+
 	</pre>
 	<br />
 


### PR DESCRIPTION
I expect `in_group` to check presence of the user in _all_ the groups, rather than the current behaviour of checking the user is in _any_ of the groups.

This pull request adds this functionality via a param that defaults to the behaviour that currently exists.
