### PR TITLE
Combine multiple calls of unset_userdata into one

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -381,9 +381,7 @@ class Ion_auth
 		$this->ion_auth_model->trigger_events('logout');
 
 		$identity = $this->config->item('identity', 'ion_auth');
-		$this->session->unset_userdata($identity);
-		$this->session->unset_userdata('id');
-		$this->session->unset_userdata('user_id');
+                $this->session->unset_userdata( array($identity => '', 'id' => '', 'user_id' => '') );
 
 		//delete the remember me cookies if they exist
 		if (get_cookie('identity'))


### PR DESCRIPTION
Because CI sends cookie on every unset_userdata call.
