### PR TITLE
Update ion_auth_mongodb_model.php to make it work out of the box

### DIFF
--- a/models/ion_auth_mongodb_model.php
+++ b/models/ion_auth_mongodb_model.php
@@ -893,7 +893,7 @@ class Ion_auth_mongodb_model extends CI_Model {
 					'identity'       => $user->{$this->identity_column},
 					'username'       => $user->username,
 					'email'          => $user->email,
-					'user_id'        => $user->_id,
+					'user_id'        => $user->_id->{'$id'},
 					'old_last_login' => $user->last_login
                 );
                 $this->session->set_userdata($session_data);
@@ -2188,7 +2188,7 @@ class Ion_auth_mongodb_model extends CI_Model {
 		}
 		elseif ( ! isset($data['id']) && isset($data['_id']))
 		{
-			$data['id'] = $data['_id'];
+			$data['id'] = $data['_id']->{'$id'};
 		}
 
 		return is_object($result) ? (object) $data : $data;


### PR DESCRIPTION
The model assumes the id property is a value. Instead, it is an MongoID object holding the $id value. This fix updates the code so the $id value is used, making several features, notably the group checking, work.
I haven't thoroughly tested it, but it passed the smoke test.
