### PR TITLE
Fixed bug in remove_from_group

### DIFF
--- a/models/ion_auth_mongodb_model.php
+++ b/models/ion_auth_mongodb_model.php
@@ -1395,7 +1395,7 @@ class Ion_auth_mongodb_model extends CI_Model {
 	 *
 	 * @return bool
 	 */
-	public function remove_from_group($group_name = FALSE, $user_id = FALSE)
+	public function remove_from_group($group_id = FALSE, $user_id = FALSE)
 	{
 		$this->trigger_events('remove_from_group');
 
@@ -1414,9 +1414,9 @@ class Ion_auth_mongodb_model extends CI_Model {
 		else
 		{
 			return $this->mongo_db
-				->where('_id', new MongoId($user_id))
-				->pull('groups', array($group_id))
-				->update($this->collections['users']);
+			->where('_id', new MongoId($user_id))
+			->pull('groups', $group_id)
+			->update($this->collections['users']);
 		}
 	}
 


### PR DESCRIPTION
Change function param group_name to group_id, and pull params from array($group_id) to $group_id.
