### PR TITLE
Fix default group addition logic

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -861,7 +861,7 @@ class Ion_auth_model extends CI_Model
 
 		//add to default group if not already set
 		$default_group = $this->where('name', $this->config->item('default_group', 'ion_auth'))->group()->row();
-		if ((isset($default_group->id) && !isset($groups)) || (empty($groups) && !in_array($default_group->id, $groups)))
+		if ((isset($default_group->id) && !isset($groups)) || (!empty($groups) && !in_array($default_group->id, $groups)))
 		{
 			$this->add_to_group($default_group->id, $id);
 		}


### PR DESCRIPTION
When the ion_auth_model register() function is called with a non-empty groups array, if the default group is not included in the groups array, the new user will not be added to the default group. This runs contrary to the comment on line 862, which indicates that the new user will be added to the default group if they haven't already been added to it.
