### PR TITLE
fix bug with identity 

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -164,7 +164,7 @@ class Auth extends CI_Controller {
 		}
 		else
 		{
-			$identity = $this->session->userdata($this->config->item('identity', 'ion_auth'));
+			$identity = $this->session->userdata('identity');
 
 			$change = $this->ion_auth->change_password($identity, $this->input->post('old'), $this->input->post('new'));
 


### PR DESCRIPTION
If identity is other than email or username (eg. identity config is id), user unable to change password.
