### PR TITLE
Change in group() method to use internal where

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -1507,7 +1507,7 @@ class Ion_auth_model extends CI_Model
 
 		if (isset($id))
 		{
-			$this->db->where($this->tables['groups'].'.id', $id);
+			$this->where($this->tables['groups'].'.id', $id);
 		}
 
 		$this->limit(1);


### PR DESCRIPTION
group() method uses now the internal where() method of the model that stores all the where filters instead using the DB CI library.
