### PR TITLE
Fix reset password code

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -773,6 +773,17 @@ class Ion_auth_model extends CI_Model
 
 		$key = $this->hash_code($activation_code_part.$identity);
 
+		// If enable query strings is set, then we need to replace any unsafe characters so that the code can still work
+		if ($key != '' && $this->config->item('permitted_uri_chars') != '' && $this->config->item('enable_query_strings') == FALSE)
+		{
+			// preg_quote() in PHP 5.3 escapes -, so the str_replace() and addition of - to preg_quote() is to maintain backwards
+			// compatibility as many are unaware of how characters in the permitted_uri_chars will be parsed as a regex pattern
+			if ( ! preg_match("|^[".str_replace(array('\\-', '\-'), '-', preg_quote($this->config->item('permitted_uri_chars'), '-'))."]+$|i", $key))
+			{
+				$key = preg_replace("/[^".$this->config->item('permitted_uri_chars')."]+/i", "-", $key);
+			}
+		}
+
 		$this->forgotten_password_code = $key;
 
 		$this->trigger_events('extra_where');


### PR DESCRIPTION
There is a condition where reset codes will contain invalid uri characters. Since the reset email uses the code and if query strings are turned off, this will cause invalid codes.

Example hash code: abc/def

When the reset code gets submitted it will read "abc" as a segment and pass it in as a code parameter instead of the full code. The forward slash causes the issue. This update replaces all invalid characters with a dash.
- fix password reset code to avoid non safe uri characters when enable
  query strings is set to false.
