### PR TITLE
Perform output encoding in the views

### DIFF
--- a/views/auth/edit_user.php
+++ b/views/auth/edit_user.php
@@ -52,7 +52,7 @@
                   }
               ?>
               <input type="checkbox" name="groups[]" value="<?php echo $group['id'];?>"<?php echo $checked;?>>
-              <?php echo $group['name'];?>
+              <?php echo htmlspecialchars($group['name'],ENT_QUOTES,'UTF-8');?>
               </label>
           <?php endforeach?>
 

--- a/views/auth/index.php
+++ b/views/auth/index.php
@@ -14,12 +14,12 @@
 	</tr>
 	<?php foreach ($users as $user):?>
 		<tr>
-			<td><?php echo $user->first_name;?></td>
-			<td><?php echo $user->last_name;?></td>
-			<td><?php echo $user->email;?></td>
+            <td><?php echo htmlspecialchars($user->first_name,ENT_QUOTES,'UTF-8');?></td>
+            <td><?php echo htmlspecialchars($user->last_name,ENT_QUOTES,'UTF-8');?></td>
+            <td><?php echo htmlspecialchars($user->email,ENT_QUOTES,'UTF-8');?></td>
 			<td>
 				<?php foreach ($user->groups as $group):?>
-					<?php echo anchor("auth/edit_group/".$group->id, $group->name) ;?><br />
+					<?php echo anchor("auth/edit_group/".$group->id, htmlspecialchars($group->name,ENT_QUOTES,'UTF-8')) ;?><br />
                 <?php endforeach?>
 			</td>
 			<td><?php echo ($user->active) ? anchor("auth/deactivate/".$user->id, lang('index_active_link')) : anchor("auth/activate/". $user->id, lang('index_inactive_link'));?></td>


### PR DESCRIPTION
global xss filter may not always be enabled, prevent malicious user
input from being executed in the admin panel.
