### PR TITLE
Revert "Update auth.php"

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -181,7 +181,7 @@ class Auth extends CI_Controller {
 	//forgot password
 	function forgot_password()
 	{
-		$this->form_validation->set_rules('email', $this->lang->line('forgot_password_validation_email_label'), 'required|valid_email');
+		$this->form_validation->set_rules('email', $this->lang->line('forgot_password_validation_email_label'), 'required');
 		if ($this->form_validation->run() == false)
 		{
 			//setup the input


### PR DESCRIPTION
The valid_email check is only applicable when user identity is email.When identity is username, this validation rule is not applicable.
