### PR TITLE
Updated forgot_password()

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -180,8 +180,18 @@ class Auth extends CI_Controller {
 
 	//forgot password
 	function forgot_password()
-	{
-		$this->form_validation->set_rules('email', $this->lang->line('forgot_password_validation_email_label'), 'required|valid_email');
+	{  
+		//setting validation rules by checking wheather identity is username or email
+		if($this->config->item('identity', 'ion_auth') == 'username' )
+		{
+		   $this->form_validation->set_rules('email', $this->lang->line('forgot_password_validation_email_label'), 'required');	
+		}
+		else
+		{
+		   $this->form_validation->set_rules('email', $this->lang->line('forgot_password_validation_email_label'), 'required|valid_email');	
+		}
+		
+		
 		if ($this->form_validation->run() == false)
 		{
 			//setup the input


### PR DESCRIPTION
If identity is set to username it was showing invalid email address. So the modified code first checks if the identity in ion config file is set to "username" or "email". If it is set to "username" we need to erase valid_email rule.
