### PR TITLE
Updated forgot_password()

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -184,7 +184,7 @@ class Auth extends CI_Controller {
 		//setting validation rules by checking wheather identity is username or email
 		if($this->config->item('identity', 'ion_auth') == 'username' )
 		{
-		   $this->form_validation->set_rules('email', $this->lang->line('forgot_password_validation_email_label'), 'required');	
+		   $this->form_validation->set_rules('email', $this->lang->line('forgot_password_username_identity_label'), 'required');	
 		}
 		else
 		{


### PR DESCRIPTION
Added proper error message display. If identity is set to username, and form is submitted without username it used to show " the email field is required". So code is modified to show the proper identity label.
