### PR TITLE
Updated forgot_password()

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -222,7 +222,16 @@ class Auth extends CI_Controller {
 				$identity = $this->ion_auth->where('email', strtolower($this->input->post('email')))->users()->row();
 			}
 	            	if(empty($identity)) {
-		        	$this->ion_auth->set_message('forgot_password_email_not_found');
+	            		
+	            		if($this->config->item('identity', 'ion_auth') == 'username')
+		            	{
+                                   $this->ion_auth->set_message('forgot_password_username_not_found');
+		            	}
+		            	else
+		            	{
+		            	   $this->ion_auth->set_message('forgot_password_email_not_found');
+		            	}
+
 		                $this->session->set_flashdata('message', $this->ion_auth->messages());
                 		redirect("auth/forgot_password", 'refresh');
             		}


### PR DESCRIPTION
If there is no such username in the database the modified code shows the error message according to the identity set in the ion config file.
Previously it used to show "No record of that email address." regardless of what identity set it uses.
