### PR TITLE
updated register() on email failure

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -362,6 +362,11 @@ class Ion_auth
 					$this->set_message('activation_email_successful');
 					return $id;
 				}
+				else
+				{
+					//code to delete inserted data if email sending fails
+					$this->ion_auth_model->delete_user($id);
+				}
 			}
 
 			$this->ion_auth_model->trigger_events(array('post_account_creation', 'post_account_creation_unsuccessful', 'activation_email_unsuccessful'));


### PR DESCRIPTION
If email doesn't go to user's email address we need to delete the added  record , so that he can retry to register, otherwise problem of duplicate identity will occur.
