### PR TITLE
Major update of the French translation in ion_auth_lang.php

### DIFF
--- a/language/french/ion_auth_lang.php
+++ b/language/french/ion_auth_lang.php
@@ -5,7 +5,7 @@
 * Author:     Stan
 * 		      tfspir@gmail.com
 *
-* Updated by: Gwenaël Galon
+* Updated by: Gwenaël Gallon
 * 			  github@dev-ggallon
 *
 * Location: http://github.com/benedmunds/ion_auth/


### PR DESCRIPTION
All missing translations in the French translation:
- Add $lang['login_timeout'] line in Login / Logout
- Add Groups lines
- Add Activation Email lines
- Add Forgot Password Email lines
- Add New Password Email lines
