### PR TITLE
Don't check if the relationship already exists

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -1416,12 +1416,6 @@ class Ion_auth_model extends CI_Model
 			$group_ids = array($group_ids);
 		}
 
-		// First check if all ids exist - num_rows() > 0 means row found
-		foreach($group_ids as $group_id)
-		{
-			if ($this->db->where(array( $this->join['groups'] => (int)$group_id, $this->join['users'] => (int)$user_id))->get($this->tables['users_groups'])->num_rows()) return false;
-		}
-
 		$return = 0;
 
 		// Then insert each into the database


### PR DESCRIPTION
This will cause a performance problem when multiple groups are parsed.

As discussed in #654
