### PR TITLE
sync migration admin password with config/ion_auth.php

### DIFF
--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -142,7 +142,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 			'id' => '1',
 			'ip_address' => 0x7f000001,
 			'username' => 'administrator',
-			'password' => '59beecdf7fc966e2f17fd8f65a4a9aeb09d4a3d4',
+			'password' => '$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa',
 			'salt' => '9462e8eee0',
 			'email' => 'admin@admin.com',
 			'activation_code' => '',


### PR DESCRIPTION
The default login/password specified in README.md currently is not working after applying 001_install_ion_auth.php. The admin password need to be changed in migration since default hash_method is bcrypt. Default configuration should work.