### PR TITLE
Group permissions

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -31,6 +31,8 @@ $config['tables']['users']           = 'users';
 $config['tables']['groups']          = 'groups';
 $config['tables']['users_groups']    = 'users_groups';
 $config['tables']['login_attempts']  = 'login_attempts';
+$config['tables']['permissions']        = 'permissions';
+$config['tables']['groups_permissions'] = 'groups_permissions';
 
 /*
  | Users table column and Group table column you want to join WITH.
@@ -40,6 +42,15 @@ $config['tables']['login_attempts']  = 'login_attempts';
  */
 $config['join']['users']  = 'user_id';
 $config['join']['groups'] = 'group_id';
+
+/*
+ | Group table column and Permissions table column you want to join WITH.
+ |
+ | Joins from groups.id
+ | Joins from permissions.id
+ */
+$config['join']['groups']      = 'group_id';
+$config['join']['permissions'] = 'permission_id';
 
 /*
  | -------------------------------------------------------------------------

--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -792,6 +792,53 @@ class Auth extends CI_Controller {
 		$this->_render_page('auth/edit_group', $this->data);
 	}
 
+	// create a new permission
+	function create_permission()
+	{
+		$this->data['title'] = $this->lang->line('create_permission_title');
+
+		if (!$this->ion_auth->logged_in() || !$this->ion_auth->has_permission('create_group_permissions'))
+		{
+			show_error("You don't have permission to create a permissions");
+		}
+
+		//validate form input
+		$this->form_validation->set_rules('permission_name', $this->lang->line('create_permission_validation_name_label'), 'required|alpha_dash|xss_clean');
+		$this->form_validation->set_rules('description', $this->lang->line('create_permission_validation_desc_label'), 'xss_clean');
+
+		if ($this->form_validation->run() == TRUE)
+		{
+			$new_permission_id = $this->ion_auth->create_permission($this->input->post('permission_name'), $this->input->post('description'));
+			if($new_permission_id)
+			{
+				// check to see if we are creating the permission
+				// redirect them back to the admin page
+				$this->session->set_flashdata('message', $this->ion_auth->messages());
+				redirect("auth", 'refresh');
+			}
+		}
+		else
+		{
+			//display the create permission form
+			//set the flash data error message if there is one
+			$this->data['message'] = (validation_errors() ? validation_errors() : ($this->ion_auth->errors() ? $this->ion_auth->errors() : $this->session->flashdata('message')));
+
+			$this->data['permission_name'] = array(
+				'name'  => 'permission_name',
+				'id'    => 'permission_name',
+				'type'  => 'text',
+				'value' => $this->form_validation->set_value('permission_name'),
+			);
+			$this->data['description'] = array(
+				'name'  => 'description',
+				'id'    => 'description',
+				'type'  => 'text',
+				'value' => $this->form_validation->set_value('description'),
+			);
+
+			$this->_render_page('auth/create_permission', $this->data);
+		}
+	}
 
 	function _get_csrf_nonce()
 	{

--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -354,7 +354,7 @@ class Auth extends CI_Controller {
 		{
 			$activation = $this->ion_auth->activate($id, $code);
 		}
-		else if ($this->ion_auth->is_admin())
+		else if ($this->ion_auth->has_permission('change_user_state'))
 		{
 			$activation = $this->ion_auth->activate($id);
 		}
@@ -376,10 +376,10 @@ class Auth extends CI_Controller {
 	//deactivate the user
 	function deactivate($id = NULL)
 	{
-		if (!$this->ion_auth->logged_in() || !$this->ion_auth->is_admin())
+		if (!$this->ion_auth->logged_in() || !$this->ion_auth->has_permission('change_user_state'))
 		{
-			//redirect them to the home page because they must be an administrator to view this
-			return show_error('You must be an administrator to view this page.');
+			//redirect them to the home page because they must have change user permission to view this
+			return show_error('You don\'t have permission to deactivate a user.');
 		}
 
 		$id = (int) $id;
@@ -408,7 +408,7 @@ class Auth extends CI_Controller {
 				}
 
 				// do we have the right userlevel?
-				if ($this->ion_auth->logged_in() && $this->ion_auth->is_admin())
+				if ($this->ion_auth->logged_in() && $this->ion_auth->has_permission('change_user_state'))
 				{
 					$this->ion_auth->deactivate($id);
 				}

--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -518,9 +518,9 @@ class Auth extends CI_Controller {
 	{
 		$this->data['title'] = "Edit User";
 
-		if (!$this->ion_auth->logged_in() || (!$this->ion_auth->is_admin() && !($this->ion_auth->user()->row()->id == $id)))
+		if (!$this->ion_auth->logged_in() || (!$this->ion_auth->has_permission('edit_user') && !($this->ion_auth->user()->row()->id == $id)))
 		{
-			redirect('auth', 'refresh');
+			show_error("You don't have permission to edit a user");
 		}
 
 		$user = $this->ion_auth->user($id)->row();
@@ -532,6 +532,7 @@ class Auth extends CI_Controller {
 		$this->form_validation->set_rules('last_name', $this->lang->line('edit_user_validation_lname_label'), 'required');
 		$this->form_validation->set_rules('phone', $this->lang->line('edit_user_validation_phone_label'), 'required');
 		$this->form_validation->set_rules('company', $this->lang->line('edit_user_validation_company_label'), 'required');
+		$this->form_validation->set_rules('groups', $this->lang->line('edit_user_validation_groups_label'), 'required');
 
 		if (isset($_POST) && !empty($_POST))
 		{

--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -424,9 +424,9 @@ class Auth extends CI_Controller {
 	{
 		$this->data['title'] = "Create User";
 
-		if (!$this->ion_auth->logged_in() || !$this->ion_auth->is_admin())
+		if (!$this->ion_auth->logged_in() || !$this->ion_auth->has_permission('create_user'))
 		{
-			redirect('auth', 'refresh');
+			show_error("You don't have permission to create a user");
 		}
 
 		$tables = $this->config->item('tables','ion_auth');

--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -17,7 +17,6 @@ class Auth extends CI_Controller {
 	//redirect if needed, otherwise display the user list
 	function index()
 	{
-
 		if (!$this->ion_auth->logged_in())
 		{
 			//redirect them to the login page
@@ -38,6 +37,13 @@ class Auth extends CI_Controller {
 			foreach ($this->data['users'] as $k => $user)
 			{
 				$this->data['users'][$k]->groups = $this->ion_auth->get_users_groups($user->id)->result();
+			}
+
+			//list groups
+			$this->data['groups'] = $this->ion_auth->groups()->result();
+			foreach ($this->data['groups'] as $k => $group)
+			{
+				$this->data['groups'][$k]->permissions = $this->ion_auth->get_groups_permissions($group->id)->result();
 			}
 
 			$this->_render_page('auth/index', $this->data);

--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -670,9 +670,9 @@ class Auth extends CI_Controller {
 	{
 		$this->data['title'] = $this->lang->line('create_group_title');
 
-		if (!$this->ion_auth->logged_in() || !$this->ion_auth->is_admin())
+		if (!$this->ion_auth->logged_in() || !$this->ion_auth->has_permission('create_users_groups'))
 		{
-			redirect('auth', 'refresh');
+                        show_error("You don't have permission to create a user groups");
 		}
 
 		//validate form input

--- a/language/english/auth_lang.php
+++ b/language/english/auth_lang.php
@@ -30,8 +30,8 @@ $lang['login_submit_btn']      = 'Login';
 $lang['login_forgot_password'] = 'Forgot your password?';
 
 // Index
-$lang['index_heading']           = 'Users';
-$lang['index_subheading']        = 'Below is a list of the users.';
+$lang['index_user_heading']           = 'Users';
+$lang['index_user_subheading']        = 'Below is a list of the users.';
 $lang['index_fname_th']          = 'First Name';
 $lang['index_lname_th']          = 'Last Name';
 $lang['index_email_th']          = 'Email';
@@ -40,8 +40,14 @@ $lang['index_status_th']         = 'Status';
 $lang['index_action_th']         = 'Action';
 $lang['index_active_link']       = 'Active';
 $lang['index_inactive_link']     = 'Inactive';
+$lang['index_group_heading']        = 'Groups';
+$lang['index_group_subheading']     = 'Below is a list of the groups.';
+$lang['index_group_name_th']        = 'Name';
+$lang['index_group_desc_th']        = 'Description';
+$lang['index_group_permissions_th'] = 'Permissions';
 $lang['index_create_user_link']  = 'Create a new user';
 $lang['index_create_group_link'] = 'Create a new group';
+$lang['index_create_permission_link'] = 'Create a new permission';
 
 // Deactivate User
 $lang['deactivate_heading']                  = 'Deactivate User';
@@ -106,6 +112,16 @@ $lang['create_group_submit_btn']             = 'Create Group';
 $lang['create_group_validation_name_label']  = 'Group Name';
 $lang['create_group_validation_desc_label']  = 'Description';
 
+// Create Permission
+$lang['create_permission_title']                  = 'Create Permission';
+$lang['create_permission_heading']                = 'Create Permission';
+$lang['create_permission_subheading']             = 'Please enter the permission information below.';
+$lang['create_permission_name_label']             = 'Permission Name:';
+$lang['create_permission_desc_label']             = 'Description:';
+$lang['create_permission_submit_btn']             = 'Create Permission';
+$lang['create_permission_validation_name_label']  = 'Permission Name';
+$lang['create_permission_validation_desc_label']  = 'Description';
+
 // Edit Group
 $lang['edit_group_title']                  = 'Edit Group';
 $lang['edit_group_saved']                  = 'Group Saved';
@@ -116,6 +132,19 @@ $lang['edit_group_desc_label']             = 'Description:';
 $lang['edit_group_submit_btn']             = 'Save Group';
 $lang['edit_group_validation_name_label']  = 'Group Name';
 $lang['edit_group_validation_desc_label']  = 'Description';
+$lang['edit_group_validation_permissions_label'] = 'Permission';
+
+// Edit Permission
+$lang['edit_permission_title']                  = 'Edit Permission';
+$lang['edit_permission_saved']                  = 'Permission Saved';
+$lang['edit_permission_heading']                = 'Edit Permission';
+$lang['edit_permission_subheading']             = 'Please enter the permission information below.';
+$lang['edit_permission_name_label']             = 'Permission Name:';
+$lang['edit_permission_desc_label']             = 'Description:';
+$lang['edit_permission_submit_btn']             = 'Save Permission';
+$lang['edit_permission_validation_name_label']  = 'Permission Name';
+$lang['edit_permission_validation_desc_label']  = 'Description';
+$lang['edit_permission_validation_permissions_label'] = 'Permission';
 
 // Change Password
 $lang['change_password_heading']                               = 'Change Password';

--- a/language/english/ion_auth_lang.php
+++ b/language/english/ion_auth_lang.php
@@ -22,7 +22,6 @@ $lang['account_creation_duplicate_username'] = 'Username Already Used or Invalid
 $lang['account_creation_missing_default_group'] = 'Default group is not set';
 $lang['account_creation_invalid_default_group'] = 'Invalid default group name set';
 
-
 // Password
 $lang['password_change_successful'] 	 	 = 'Password Successfully Changed';
 $lang['password_change_unsuccessful'] 	  	 = 'Unable to Change Password';
@@ -49,6 +48,14 @@ $lang['update_successful'] 		 	         = 'Account Information Successfully Upda
 $lang['update_unsuccessful'] 		 	     = 'Unable to Update Account Information';
 $lang['delete_successful']               = 'User Deleted';
 $lang['delete_unsuccessful']           = 'Unable to Delete User';
+
+// Permissions
+$lang['permission_creation_successful']  = 'Permission created Successfully';
+$lang['permission_already_exists']       = 'Permission name already taken';
+$lang['permission_update_successful']    = 'Permission details updated';
+$lang['permission_delete_successful']    = 'Permission deleted';
+$lang['permission_delete_unsuccessful']  = 'Unable to delete permission';
+$lang['permission_name_required']        = 'Permission name is a required field';
 
 // Groups
 $lang['group_creation_successful']  = 'Group created Successfully';

--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -1,3 +1,30 @@
+DROP TABLE IF EXISTS `permissions`;
+
+#
+# Table structure for table 'permissions'
+#
+
+CREATE TABLE `permissions` (
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) NOT NULL,
+  `description` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+#
+# Dumping data for table 'permissions'
+#
+
+INSERT INTO `permissions` (`id`, `name`, `description`) VALUES
+     (1,'create_user','Create new user'),
+     (2,'edit_user','Edit user details'),
+     (3,'change_user_state','Activate/Deactivate User'),
+     (4,'view_all_users','Get list of all users'),
+     (5,'create_users_groups','Create users groups'),
+     (6,'edit_users_groups','Edit users groups'),
+     (7,'create_group_permissions','Create group permissions'),
+     (8,'edit_group_permissions','Edit group permissions');
+
 DROP TABLE IF EXISTS `groups`;
 
 #
@@ -19,6 +46,34 @@ INSERT INTO `groups` (`id`, `name`, `description`) VALUES
      (1,'admin','Administrator'),
      (2,'members','General User');
 
+
+DROP TABLE IF EXISTS `groups_permissions`;
+
+#
+# Table structure for table 'groups_permissions'
+#
+
+CREATE TABLE `groups_permissions` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL,
+  `permission_id` mediumint(8) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_groups_permissions_groups1_idx` (`group_id`),
+  KEY `fk_groups_permissions_permissions1_idx` (`permission_id`),
+  CONSTRAINT `uc_groups_permissions` UNIQUE (`group_id`, `permission_id`),
+  CONSTRAINT `fk_groups_permissions_groups1` FOREIGN KEY (`group_id`) REFERENCES `groups` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `fk_groups_permissions_permissions1` FOREIGN KEY (`permission_id`) REFERENCES `permissions` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `groups_permissions` (`id`, `group_id`, `permission_id`) VALUES
+     (1,1,1),
+     (2,1,2),
+     (3,1,3),
+     (4,1,4),
+     (5,1,5),
+     (6,1,6),
+     (7,1,7),
+     (8,1,8);
 
 
 DROP TABLE IF EXISTS `users`;

--- a/views/auth/create_permission.php
+++ b/views/auth/create_permission.php
@@ -1,0 +1,20 @@
+<h1><?php echo lang('create_permission_heading');?></h1>
+<p><?php echo lang('create_permission_subheading');?></p>
+
+<div id="infoMessage"><?php echo $message;?></div>
+
+<?php echo form_open("auth/create_permission");?>
+
+      <p>
+            <?php echo lang('create_permission_name_label', 'permission_name');?> <br />
+            <?php echo form_input($permission_name);?>
+      </p>
+
+      <p>
+            <?php echo lang('create_permission_desc_label', 'description');?> <br />
+            <?php echo form_input($description);?>
+      </p>
+
+      <p><?php echo form_submit('submit', lang('create_permission_submit_btn'));?></p>
+
+<?php echo form_close();?>

--- a/views/auth/edit_group.php
+++ b/views/auth/edit_group.php
@@ -15,6 +15,29 @@
             <?php echo form_input($group_description);?>
       </p>
 
+      <?php if ($this->ion_auth->has_permission('edit_group_permissions')): ?>
+
+          <h3><?php echo lang('edit_groups_permissions_heading');?></h3>
+          <?php foreach ($permissions as $permission):?>
+              <label class="checkbox">
+              <?php
+                  $pID=$permission['id'];
+                  $checked = null;
+                  $item = null;
+                  foreach($currentPermissions as $per) {
+                      if ($pID == $per->id) {
+                          $checked= ' checked="checked"';
+                      break;
+                      }
+                  }
+              ?>
+              <input type="checkbox" name="permissions[]" value="<?php echo $permission['id'];?>"<?php echo $checked;?>>
+              <?php echo $permission['description'];?>
+              </label>
+          <?php endforeach?>
+
+      <?php endif ?>
+
       <p><?php echo form_submit('submit', lang('edit_group_submit_btn'));?></p>
 
 <?php echo form_close();?>

--- a/views/auth/edit_permission.php
+++ b/views/auth/edit_permission.php
@@ -1,0 +1,20 @@
+<h1><?php echo lang('edit_permission_heading');?></h1>
+<p><?php echo lang('edit_permission_subheading');?></p>
+
+<div id="infoMessage"><?php echo $message;?></div>
+
+<?php echo form_open(current_url());?>
+
+      <p>
+            <?php echo lang('edit_permission_name_label', 'permission_name');?> <br />
+            <?php echo form_input($permission_name);?>
+      </p>
+
+      <p>
+            <?php echo lang('edit_permission_desc_label', 'description');?> <br />
+            <?php echo form_input($permission_description);?>
+      </p>
+
+      <p><?php echo form_submit('submit', lang('edit_permission_submit_btn'));?></p>
+
+<?php echo form_close();?>

--- a/views/auth/index.php
+++ b/views/auth/index.php
@@ -1,5 +1,5 @@
-<h1><?php echo lang('index_heading');?></h1>
-<p><?php echo lang('index_subheading');?></p>
+<h1><?php echo lang('index_user_heading');?></h1>
+<p><?php echo lang('index_user_subheading');?></p>
 
 <div id="infoMessage"><?php echo $message;?></div>
 
@@ -19,7 +19,7 @@
             <td><?php echo htmlspecialchars($user->email,ENT_QUOTES,'UTF-8');?></td>
 			<td>
 				<?php foreach ($user->groups as $group):?>
-					<?php echo anchor("auth/edit_group/".$group->id, htmlspecialchars($group->name,ENT_QUOTES,'UTF-8')) ;?><br />
+					<?php echo htmlspecialchars($group->name,ENT_QUOTES,'UTF-8') ;?><br />
                 <?php endforeach?>
 			</td>
 			<td><?php echo ($user->active) ? anchor("auth/deactivate/".$user->id, lang('index_active_link')) : anchor("auth/activate/". $user->id, lang('index_inactive_link'));?></td>
@@ -28,4 +28,32 @@
 	<?php endforeach;?>
 </table>
 
-<p><?php echo anchor('auth/create_user', lang('index_create_user_link'))?> | <?php echo anchor('auth/create_group', lang('index_create_group_link'))?></p>
+<hr>
+
+<h1><?php echo lang('index_group_heading');?></h1>
+<p><?php echo lang('index_group_subheading');?></p>
+
+<table cellpadding=0 cellspacing=15>
+        <tr>
+                <th><?php echo lang('index_group_name_th');?></th>
+                <th><?php echo lang('index_group_desc_th');?></th>
+                <th><?php echo lang('index_group_permissions_th');?></th>
+                <th><?php echo lang('index_action_th');?></th>
+        </tr>
+        <?php foreach ($groups as $group):?>
+                <tr>
+                        <td><?php echo htmlspecialchars($group->name,ENT_QUOTES,'UTF-8');?></td>
+                        <td><?php echo htmlspecialchars($group->description,ENT_QUOTES,'UTF-8');?></td>
+                        <td>
+                            <?php foreach ($group->permissions as $permission):?>
+                                <?php echo anchor("auth/edit_permission/".$permission->id, htmlspecialchars($permission->description,ENT_QUOTES,'UTF-8')) ;?><br />
+                            <?php endforeach?>
+                        </td>
+                        <td><?php echo anchor("auth/edit_group/".$group->id, 'Edit') ;?></td>
+                </tr>
+        <?php endforeach;?>
+</table>
+
+<hr>
+
+<p><?php echo anchor('auth/create_user', lang('index_create_user_link'))?> | <?php echo anchor('auth/create_group', lang('index_create_group_link'))?> | <?php echo anchor('auth/create_permission', lang('index_create_permission_link'))?></p>


### PR DESCRIPTION
Add new role based (like on Spring) feature.

Now each group has one or many permissions assigned. When member is assigned with a group all permissions of that group will be assigned to that user. And we can check whether user has sufficient permission to perform some task by using has_permission() method.

e.g. has_permission('create_new_user')

Also It would be enough to assign a user only to a single group because several groups can be created which have different access permissions. But I did not change database schema (still has many-to-many) & logic because I need to keep this pull request simple.

I don't have access progress & ms sql databases so I did not update those sql files.

DB Design:
![ion_db_new](https://cloud.githubusercontent.com/assets/2670029/5935153/aef77b58-a6fd-11e4-9da2-a727f967d4b0.png)