### PR TITLE
create_user() and update_user() alternate methods

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -106,7 +106,14 @@ class Ion_auth
 		{
 			throw new Exception('Undefined method Ion_auth::' . $method . '() called');
 		}
-
+		if($method == 'create_user')
+		{
+			return call_user_func_array(array($this, 'register'), $arguments);
+		}
+		if($method=='update_user')
+		{
+			return call_user_func_array(array($this, 'update'), $arguments);
+		}
 		return call_user_func_array( array($this->ion_auth_model, $method), $arguments);
 	}
 


### PR DESCRIPTION
We should keep consistent method names. If you have delete_user(), create_group(), update_group(), delete_group(), we should also have create_user() and update_user().