### PR TITLE
unambigous order_by

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -1397,7 +1397,7 @@ class Ion_auth_model extends CI_Model
 		$id || $id = $this->session->userdata('user_id');
 
 		$this->limit(1);
-		$this->order_by('id', 'desc');
+		$this->order_by($this->tables['users'].'.id', 'desc');
 		$this->where($this->tables['users'].'.id', $id);
 
 		$this->users();


### PR DESCRIPTION
...as per issue #402 (although I don't understand why do we need to order by id as long as the limit is already set to 1 and we are given an id...)