### PR TITLE
Update index.html

### DIFF
--- a/userguide/index.html
+++ b/userguide/index.html
@@ -308,7 +308,7 @@ Documentation
 								'first_name' => 'Ben',
 								'last_name' => 'Edmunds',
 								);
-		$group = array('1'); // Sets user to admin. No need for array('1', '2') as user is always set to member by default
+		$group = array('1'); // Sets user to admin.
 
 		$this->ion_auth->register($username, $password, $email, $additional_data, $group)
 	</pre>


### PR DESCRIPTION
Comments erroneously state:

>  No need for array('1', '2') as user is always set to member by default

This is simply not true.  The new user will only be put into the exact groups specified within the Group array.  The new user is NOT automatically put into the default group, unless the `Group` parameter is omitted entirely.  Tested on 06/19/2015