### PR TITLE
Update Ion_auth.php

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -386,8 +386,15 @@ class Ion_auth
 
 		$identity = $this->config->item('identity', 'ion_auth');
                 
-                $this->session->unset_userdata( array($identity, 'id', 'user_id') );
-
+                if (substr(CI_VERSION, 0, 1) == '2')
+		{
+			$this->session->unset_userdata( array($identity => '', 'id' => '', 'user_id' => '') );
+                } 
+                else 
+                {
+                	$this->session->unset_userdata( array($identity, 'id', 'user_id') );
+                }
+                
 		//delete the remember me cookies if they exist
 		if (get_cookie($this->config->item('identity_cookie_name', 'ion_auth')))
 		{

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -385,7 +385,8 @@ class Ion_auth
 		$this->ion_auth_model->trigger_events('logout');
 
 		$identity = $this->config->item('identity', 'ion_auth');
-                $this->session->unset_userdata( array($identity => '', 'id' => '', 'user_id' => '') );
+                
+                $this->session->unset_userdata( array($identity, 'id', 'user_id') );
 
 		//delete the remember me cookies if they exist
 		if (get_cookie($this->config->item('identity_cookie_name', 'ion_auth')))
@@ -423,8 +424,9 @@ class Ion_auth
 	public function logged_in()
 	{
 		$this->ion_auth_model->trigger_events('logged_in');
-
-		return (bool) $this->session->userdata('identity');
+		$identity = $this->config->item('identity', 'ion_auth');
+		
+		return (bool) $this->session->userdata($identity);
 	}
 
 	/**


### PR DESCRIPTION
Fixed one issue with identity not properly set to the user configured field in when checking if the user is logged in.

Removed the associative array used in unset_userdata, as this is no longer supported in CI 3.x

Please bear in mind you may need to use the old associative array notation in CI 2.x ? (I do not use it, so I cannot test).

