### PR TITLE
get_attempt_num() to return results by ip address AND identity...

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -1058,8 +1058,10 @@ class Ion_auth_model extends CI_Model
         if ($this->config->item('track_login_attempts', 'ion_auth')) {
             $ip_address = $this->_prepare_ip($this->input->ip_address());
             $this->db->select('1', FALSE);
-            if ($this->config->item('track_login_ip_address', 'ion_auth')) $this->db->where('ip_address', $ip_address);
-            else if (strlen($identity) > 0) $this->db->or_where('login', $identity);
+            if ($this->config->item('track_login_ip_address', 'ion_auth')) {
+            	$this->db->where('ip_address', $ip_address);
+            	$this->db->where('login', $identity);
+            } else if (strlen($identity) > 0) $this->db->or_where('login', $identity);
             $qres = $this->db->get($this->tables['login_attempts']);
             return $qres->num_rows();
         }


### PR DESCRIPTION
when track_login_ip_address is set to TRUE. This corrects an issue where get_attempt_num() would count any login from an ip address, regardless of user, and limit the number of attempts at logging in to less than specified in the config table