### PR TITLE
set username default as null

### DIFF
--- a/sql/ion_auth.mssql.sql
+++ b/sql/ion_auth.mssql.sql
@@ -1,7 +1,7 @@
 CREATE TABLE users (
     id int NOT NULL IDENTITY(1,1),
     ip_address varchar(15) NOT NULL,
-    username varchar(100) NOT NULL,
+    username varchar(100) NULL,
     password varchar(255) NOT NULL,
     salt varchar(255),
     email varchar(100) NOT NULL,

--- a/sql/ion_auth.postgre.sql
+++ b/sql/ion_auth.postgre.sql
@@ -1,7 +1,7 @@
 CREATE TABLE "users" (
     "id" SERIAL NOT NULL,
     "ip_address" varchar(15),
-    "username" varchar(100) NOT NULL,
+    "username" varchar(100) NULL,
     "password" varchar(255) NOT NULL,
     "salt" varchar(255),
     "email" varchar(100) NOT NULL,

--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -30,7 +30,7 @@ DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `ip_address` varchar(15) NOT NULL,
-  `username` varchar(100) NOT NULL,
+  `username` varchar(100) NULL,
   `password` varchar(255) NOT NULL,
   `salt` varchar(255) DEFAULT NULL,
   `email` varchar(100) NOT NULL,


### PR DESCRIPTION
when using another field as identity and not username, the username field can also be null.