### PR TITLE
more explaining on register() method.

### DIFF
--- a/userguide/index.html
+++ b/userguide/index.html
@@ -287,7 +287,7 @@ Documentation
 
 	<p><strong>Parameters</strong></p>
 	<ol>
-		<li>'Username' - string REQUIRED.</li>
+		<li>'Identity' - string REQUIRED. This must be the value that uniquely identifies the user when he is registered. If you chose "email" as $config['identity'] in the configuration file, you must put the email of the new user.</li>
 		<li>'Password' - string REQUIRED.</li>
 		<li>'Email' - string REQUIRED.</li>
 		<li>'Additional Data' - multidimensional array OPTIONAL.</li>


### PR DESCRIPTION
This is to make sure the users understand that they must put the identity column, even if that is an email.