### PR TITLE
we remove the posibility of setting 0 as user_id

### DIFF
--- a/models/ion_auth_model.php
+++ b/models/ion_auth_model.php
@@ -1378,7 +1378,7 @@ class Ion_auth_model extends CI_Model
 		$this->trigger_events('user');
 
 		// if no id was passed use the current users id
-		$id || $id = $this->session->userdata('user_id');
+		$id = isset($id) ? $id : $this->session->userdata('user_id');
 
 		$this->limit(1);
 		$this->order_by($this->tables['users'].'.id', 'desc');


### PR DESCRIPTION
I don't know how this helps, but is good to make sure if no id was passed or not.