### PR TITLE
Fixed Ion_auth_model for username input

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -899,6 +899,7 @@ class Ion_auth_model extends CI_Model
 		// Users table.
 		$data = array(
 		    $this->identity_column   => $identity,
+		    'username'   => $identity,
 		    'password'   => $password,
 		    'email'      => $email,
 		    'ip_address' => $ip_address,


### PR DESCRIPTION
Before the update, if the setting for identity in ion_auth config was "email", when creating a new user a username field would be left blank. This fixes the issue for both ways to identify users (both "email" and "username").

This solution was given by Aleix.
