### PR TITLE
Check post var against NULL instead of FALSE

### DIFF
--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -795,7 +795,7 @@ class Auth extends CI_Controller {
 
 	public function _valid_csrf_nonce()
 	{
-		if ($this->input->post($this->session->flashdata('csrfkey')) !== FALSE &&
+		if ($this->input->post($this->session->flashdata('csrfkey')) !== NULL &&
 			$this->input->post($this->session->flashdata('csrfkey')) == $this->session->flashdata('csrfvalue'))
 		{
 			return TRUE;

--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -795,8 +795,8 @@ class Auth extends CI_Controller {
 
 	public function _valid_csrf_nonce()
 	{
-		if ($this->input->post($this->session->flashdata('csrfkey')) !== NULL &&
-			$this->input->post($this->session->flashdata('csrfkey')) == $this->session->flashdata('csrfvalue'))
+		$csrfkey = $this->input->post($this->session->flashdata('csrfkey'));
+		if ($csrfkey && $csrfkey == $this->session->flashdata('csrfvalue'))
 		{
 			return TRUE;
 		}


### PR DESCRIPTION
`$this->input->post()` now returns NULL instead of FALSE when the required items don’t exist.

See for reference: http://www.codeigniter.com/user_guide/installation/upgrade_300.html#step-10-many-functions-now-return-null-instead-of-false-on-missing-items
