### PR TITLE
"remember me" doesn't work correctly

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1810,7 +1810,7 @@ class Ion_auth_model extends CI_Model
 		// get the user
 		$this->trigger_events('extra_where');
 		$query = $this->db->select($this->identity_column.', id, email, last_login')
-		                  ->where($this->identity_column, get_cookie($this->config->item('identity_cookie_name', 'ion_auth')))
+		                  ->where($this->identity_column, url_decode(get_cookie($this->config->item('identity_cookie_name', 'ion_auth'))))
 		                  ->where('remember_code', get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
 		                  ->limit(1)
 		    			  ->order_by('id', 'desc')


### PR DESCRIPTION
If identity column is the email then, when the email is saved in the cookie the "@" symbol is "%40" and when the database is queried, it will return false.
As per issue #1001. @italoc maybe you should try this change to see if it works before it is merged.