### PR TITLE
Fixed 'login attempts' functionality. 

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1047,19 +1047,18 @@ class Ion_auth_model extends CI_Model
 	 * @param	string $identity
 	 * @return	int
 	 */
-	public function get_attempts_num($identity)
-	{
-        if ($this->config->item('track_login_attempts', 'ion_auth')) {
-            $ip_address = $this->_prepare_ip($this->input->ip_address());
-            $this->db->select('1', FALSE);
-            if ($this->config->item('track_login_ip_address', 'ion_auth')) {
-            	$this->db->where('ip_address', $ip_address);
-            	$this->db->where('login', $identity);
-            } else if (strlen($identity) > 0) $this->db->or_where('login', $identity);
-            $qres = $this->db->get($this->tables['login_attempts']);
-            return $qres->num_rows();
-        }
-        return 0;
+	public function get_attempts_num($identity) {
+		if ($this->config->item('track_login_attempts', 'ion_auth')) {
+			$ip_address = $this->_prepare_ip($this->input->ip_address());
+			$this->db->select('1', FALSE);
+			if ($this->config->item('track_login_ip_address', 'ion_auth'))
+				$this->db->where('ip_address', $ip_address);
+			if (strlen($identity) > 0)
+				$this->db->or_where('login', $identity);
+			$qres = $this->db->get($this->tables['login_attempts']);
+			return $qres->num_rows();
+		}
+		return 0;
 	}
 
 	/**
@@ -1084,12 +1083,14 @@ class Ion_auth_model extends CI_Model
 			$ip_address = $this->_prepare_ip($this->input->ip_address());
 
 			$this->db->select('time');
-            if ($this->config->item('track_login_ip_address', 'ion_auth')) $this->db->where('ip_address', $ip_address);
-			else if (strlen($identity) > 0) $this->db->or_where('login', $identity);
+			if ($this->config->item('track_login_ip_address', 'ion_auth'))
+				$this->db->where('ip_address', $ip_address);
+			if (strlen($identity) > 0)
+				$this->db->or_where('login', $identity);
 			$this->db->order_by('id', 'desc');
 			$qres = $this->db->get($this->tables['login_attempts'], 1);
 
-			if($qres->num_rows() > 0) {
+			if ($qres->num_rows() > 0) {
 				return $qres->row()->time;
 			}
 		}


### PR DESCRIPTION
Methods 'get_attempts_num' and 'get_last_attempt_time' had different logic. This is fixed.
We should check both IP address and itentity to avoid bruteforce different logins from one IP as well as avoid bruteforce one login from different IPs.