### PR TITLE
Add otp to the select in login function

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1112,7 +1112,7 @@ class Ion_auth_model extends CI_Model {
 
         $this->trigger_events('extra_where');
 
-        $query = $this->db->select($this->identity_column . ', email, id, password, active, last_login')
+        $query = $this->db->select($this->identity_column . ', email, id, password, otp, active, last_login')
                 ->where($this->identity_column, $identity)
                 ->limit(1)
                 ->order_by('id', 'desc')


### PR DESCRIPTION
Having previously worked with this branch, I noted that the select in the login function was missing the otp column, resulting in an error/warning in the model on line 1145. This should fix it.