### PR TITLE
Fix Google SMTP Failed to authenticate password Error: 535-5.7.8

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -78,6 +78,7 @@ class Ion_auth
 		if ($this->config->item('use_ci_email', 'ion_auth') && isset($email_config) && is_array($email_config))
 		{
 			$this->email->initialize($email_config);
+			$this->email->set_newline("\r\n");
 		}
 
 		$this->ion_auth_model->trigger_events('library_constructor');


### PR DESCRIPTION
##### Fix Google SMTP Failed to Authenticate Password Issue even with correct username and password!

Hi @benedmunds , 
I'm using CodeIgniter 3.1.0 with PHP 7.0.13 on Ubuntu 16.04.1
First I created a simple send email function in my controller and I was able to successfully send emails with the following settings found in `application/config/email.php`

```
$config['protocol'] = 'smtp';
$config['charset'] = 'iso-8859-1';
$config['wordwrap'] = TRUE;
$config['mailtype'] = "html";
$config['smtp_timeout'] = "60";
$config['smtp_host'] = 'ssl://smtp.googlemail.com';
$config['smtp_user'] = 'username';
$config['smtp_pass'] = 'password';
$config['smtp_crypto'] = 'ssl';
$config['smtp_port'] = 465;
```
I also had to enable less secure apps on Google [here](https://www.google.com/settings/security/lesssecureapps?). 

I passed the same settings to ion_Auth's `$config['email_config'] ` but I got the following error when using the reset password route. 
```
'220 smtp.googlemail.com ESMTP g23sm5431585wme.27 - gsmtp
<br /><pre>hello: 250-smtp.googlemail.com at your service, [0.00.00.000]
250-SIZE 35882577
250-8BITMIME
250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH
250-ENHANCEDSTATUSCODES
250-PIPELINING
250-CHUNKING
250 SMTPUTF8
</pre>Failed to authenticate password. Error: 535-5.7.8 Username and Password not accepted. Learn more at
535 5.7.8  https://support.google.com/mail/?p=BadCredentials g23sm5431585wme.27 - gsmtp
<br />Unable to'... (length=1181)
```

After a bit of research, I found the fix implemented in this PR [here](https://expressionengine.com/forums/archive/topic/132443/sending-email-with-gmail-smtp-with-codeigniter-email-library).

Thanks. 
