### PR TITLE
edit only group description

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1958,7 +1958,7 @@ class Ion_auth_model extends CI_Model
 
 		// restrict change of name of the admin group
         $group = $this->db->get_where($this->tables['groups'], array('id' => $group_id))->row();
-        if($this->config->item('admin_group', 'ion_auth') === $group->name && $group_name !== $group->name)
+        if($this->config->item('admin_group', 'ion_auth') === $group->name && $group_name !== $group->name && $group_name)
         {
             $this->set_error('group_name_admin_not_alter');
             return FALSE;


### PR DESCRIPTION
allowing edit all description,but not all name of groups,

the parameter will be is the ID and Description. while the name set to FALSE to ignore update on name.

```php
          //after validation input
	   $group_update = $this->ion_auth->update_group(
                $id, FALSE, $this->input->post('description', TRUE)
         );

```