### PR TITLE
add missing lang in forgot_password_identity_not_found

### DIFF
--- a/language/arabic/auth_lang.php
+++ b/language/arabic/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/bulgarian/auth_lang.php
+++ b/language/bulgarian/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/catalan/auth_lang.php
+++ b/language/catalan/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label'] = 'Adreça de Correu-e';
 $lang['forgot_password_identity_label']         = 'Usuari';
 $lang['forgot_password_email_identity_label']   = 'Correu-e';
 $lang['forgot_password_email_not_found']        = 'No hi ha registre d\'aquesta adreça de correu electrònic.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Canvia Contrasenya';

--- a/language/croatian/auth_lang.php
+++ b/language/croatian/auth_lang.php
@@ -137,6 +137,7 @@ $lang['forgot_password_validation_email_label']  = 'Email';
 $lang['forgot_password_username_identity_label'] = 'Korisničko ime';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Promjena lozinke';

--- a/language/czech/auth_lang.php
+++ b/language/czech/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/danish/auth_lang.php
+++ b/language/danish/auth_lang.php
@@ -147,6 +147,7 @@ $lang['forgot_password_validation_email_label']  = 'Email-adresse';
 $lang['forgot_password_username_identity_label'] = 'Brugernavn';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Skift Kodeord';

--- a/language/dutch/auth_lang.php
+++ b/language/dutch/auth_lang.php
@@ -138,6 +138,7 @@ $lang['forgot_password_validation_email_label']  = 'E-mailadres';
 $lang['forgot_password_username_identity_label'] = 'Gebruikersnaam';
 $lang['forgot_password_email_identity_label']    = 'E-mail';
 $lang['forgot_password_email_not_found']         = 'Het opgegeven e-mailadres werd niet terug gevonden.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Wachtwoord wijzigen';

--- a/language/english/auth_lang.php
+++ b/language/english/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_identity_label'] = 'Identity';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/english/auth_lang.php
+++ b/language/english/auth_lang.php
@@ -134,7 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_identity_label'] = 'Identity';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
-$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/estonian/auth_lang.php
+++ b/language/estonian/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/filipino/auth_lang.php
+++ b/language/filipino/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_identity_label'] = 'Identity';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Walang record ng email address.';
+$lang['forgot_password_identity_not_found']         = 'Walang record ng username.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Palitan ang Password';

--- a/language/finnish/auth_lang.php
+++ b/language/finnish/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/french/auth_lang.php
+++ b/language/french/auth_lang.php
@@ -136,6 +136,7 @@ $lang['forgot_password_validation_email_label']  = 'Adresse Email';
 $lang['forgot_password_username_identity_label'] = 'Nom d\'utilisateur';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Cette adresse email n\'est pas enregistrée chez nous.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Modifier le mot de passe';

--- a/language/german/auth_lang.php
+++ b/language/german/auth_lang.php
@@ -140,6 +140,7 @@ $lang['forgot_password_submit_btn']              = 'Eingabe';
 $lang['forgot_password_validation_email_label']  = 'Email';
 $lang['forgot_password_username_identity_label'] = 'Benutzername';
 $lang['forgot_password_email_identity_label']    = 'Email';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 
 // Reset Password

--- a/language/greek/auth_lang.php
+++ b/language/greek/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/hungarian/auth_lang.php
+++ b/language/hungarian/auth_lang.php
@@ -132,6 +132,7 @@ $lang['forgot_password_validation_email_label']  = 'E-mail cím';
 $lang['forgot_password_username_identity_label'] = 'Felhasználónév';
 $lang['forgot_password_email_identity_label']    = 'E-mail';
 $lang['forgot_password_email_not_found']         = 'Nem található ez az e-mail cím.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Jelszó változtatása';

--- a/language/indonesian/auth_lang.php
+++ b/language/indonesian/auth_lang.php
@@ -135,6 +135,7 @@ $lang['forgot_password_validation_email_label']  = 'Alamat Surel';
 $lang['forgot_password_username_identity_label'] = 'Nama Pengguna';
 $lang['forgot_password_email_identity_label']    = 'Surel';
 $lang['forgot_password_email_not_found']         = 'Tidak ada data dari surel tersebut.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Ganti Kata Sandi';

--- a/language/italian/auth_lang.php
+++ b/language/italian/auth_lang.php
@@ -138,6 +138,7 @@ $lang['forgot_password_validation_email_label']  = 'Indirizzo Email';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Indirizzo email non presente nel database.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Cambia Password';

--- a/language/japanese/auth_lang.php
+++ b/language/japanese/auth_lang.php
@@ -138,6 +138,7 @@ $lang['forgot_password_validation_email_label']  = 'メールアドレス';
 $lang['forgot_password_username_identity_label'] = 'ユーザー名';
 $lang['forgot_password_email_identity_label']    = 'メールアドレス';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'パスワードの変更';

--- a/language/korean/auth_lang.php
+++ b/language/korean/auth_lang.php
@@ -135,6 +135,7 @@ $lang['forgot_password_validation_email_label']  = '이메일 주소';
 $lang['forgot_password_username_identity_label'] = '계정명';
 $lang['forgot_password_email_identity_label']    = '이메일';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = '비밀번호 바꾸기';

--- a/language/lithuanian/auth_lang.php
+++ b/language/lithuanian/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'El. p. adresas';
 $lang['forgot_password_username_identity_label'] = 'Vartotojo vardas';
 $lang['forgot_password_email_identity_label']    = 'El. p. adresas';
 $lang['forgot_password_email_not_found']         = 'Duomenų bazėje tokio el. pašto adreso nėra.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset password
 $lang['reset_password_heading']                               = 'Pakeisti slaptažodį';

--- a/language/norwegian/auth_lang.php
+++ b/language/norwegian/auth_lang.php
@@ -143,6 +143,7 @@ $lang['forgot_password_validation_email_label']  = 'Email';
 $lang['forgot_password_username_identity_label'] = 'Brukernavn';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Vi fant ikke emailen du oppgav.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Endre passord';

--- a/language/persian/auth_lang.php
+++ b/language/persian/auth_lang.php
@@ -130,6 +130,7 @@ $lang['forgot_password_validation_email_label']  = 'آدرس ایمیل';
 $lang['forgot_password_username_identity_label'] = 'نام کاربری';
 $lang['forgot_password_email_identity_label']    = 'ایمیل';
 $lang['forgot_password_email_not_found']         = 'اطلاعات یافت نشد';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'تغییر کلمه عبور';

--- a/language/pirate/auth_lang.php
+++ b/language/pirate/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/polish/auth_lang.php
+++ b/language/polish/auth_lang.php
@@ -137,6 +137,7 @@ $lang['forgot_password_validation_email_label']  = 'Adres email';
 $lang['forgot_password_username_identity_label'] = 'Użytkownik';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Nie znaleziono w bazie użytkownika o tym adresie.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                    			  = 'Zmiana hasła';

--- a/language/portuguese/auth_lang.php
+++ b/language/portuguese/auth_lang.php
@@ -136,6 +136,7 @@ $lang['forgot_password_validation_email_label']  = 'Email';
 $lang['forgot_password_username_identity_label'] = 'Login';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Este email não foi encontrado.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Mudar Senha';

--- a/language/romanian/auth_lang.php
+++ b/language/romanian/auth_lang.php
@@ -131,6 +131,7 @@ $lang['forgot_password_validation_email_label']  = 'Adresa de email';
 $lang['forgot_password_username_identity_label'] = 'Utilizator';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Nu există nicio înregistrare cu acest email.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Schimbare parolă';

--- a/language/russian/auth_lang.php
+++ b/language/russian/auth_lang.php
@@ -142,6 +142,7 @@ $lang['forgot_password_username_identity_label'] = 'Логин';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_back']    = 'Вернуться';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Изменить пароль';

--- a/language/slovak/auth_lang.php
+++ b/language/slovak/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label'] = 'E-mailová adresa';
 $lang['forgot_password_username_identity_label'] = 'Používateľské meno';
 $lang['forgot_password_email_identity_label'] = 'Email';
 $lang['forgot_password_email_not_found'] = 'Žiadny záznam s toutu e-mailovou adresou.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading'] = 'Zmena hesla';

--- a/language/slovenian/auth_lang.php
+++ b/language/slovenian/auth_lang.php
@@ -132,6 +132,7 @@ $lang['forgot_password_validation_email_label']  = 'Elektronski naslov';
 $lang['forgot_password_username_identity_label'] = 'Uporabniško ime';
 $lang['forgot_password_email_identity_label']    = 'E-naslov';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Ponastavi geslo
 $lang['reset_password_heading']                               = 'Spremeni geslo';

--- a/language/spanish/auth_lang.php
+++ b/language/spanish/auth_lang.php
@@ -137,6 +137,7 @@ $lang['forgot_password_validation_email_label']  = 'Correo Electrónico';
 $lang['forgot_password_username_identity_label'] = 'Usuario';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'El correo electrónico no existe.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Cambiar Contraseña';

--- a/language/swedish/auth_lang.php
+++ b/language/swedish/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Adress';
 $lang['forgot_password_username_identity_label'] = 'Användarnamn';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Email adressen finns inte i vårt register.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Ändra Lösenord';

--- a/language/thai/auth_lang.php
+++ b/language/thai/auth_lang.php
@@ -142,6 +142,7 @@ $lang['forgot_password_validation_email_label']  = 'ที่อยู่อี�
 $lang['forgot_password_username_identity_label'] = 'ชื่อผู้ใช้';
 $lang['forgot_password_email_identity_label']    = 'อีเมล์';
 $lang['forgot_password_email_not_found']         = 'ไม่พบที่อยู่อีเมล์นี้ในสารบบ';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // ตั้งรหัสผ่านใหม่
 $lang['reset_password_heading']                               = 'ตั้งรหัสผ่านใหม่';

--- a/language/turkish/auth_lang.php
+++ b/language/turkish/auth_lang.php
@@ -135,6 +135,7 @@ $lang['forgot_password_validation_email_label']  = 'Eposta Adresi';
 $lang['forgot_password_username_identity_label'] = 'Kullanıcı Adı';
 $lang['forgot_password_email_identity_label']    = 'Eposta';
 $lang['forgot_password_email_not_found']         = 'Belirttiğiniz Eposta adresi için bir kayıt bulunamadı.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Şifre Değiştirme';

--- a/language/ukrainian/auth_lang.php
+++ b/language/ukrainian/auth_lang.php
@@ -134,6 +134,7 @@ $lang['forgot_password_validation_email_label']  = 'Email Address';
 $lang['forgot_password_username_identity_label'] = 'Username';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'No record of that email address.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Change Password';

--- a/language/vietnamese/auth_lang.php
+++ b/language/vietnamese/auth_lang.php
@@ -135,6 +135,7 @@ $lang['forgot_password_validation_email_label']  = 'Email';
 $lang['forgot_password_username_identity_label'] = 'Tài khoản';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Địa chỉ email không tồn tại.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = 'Đổi mật khẩu';

--- a/language/zh_cn/auth_lang.php
+++ b/language/zh_cn/auth_lang.php
@@ -141,6 +141,7 @@ $lang['forgot_password_validation_email_label']  = '邮箱地址';
 $lang['forgot_password_username_identity_label'] = '用户名';
 $lang['forgot_password_email_identity_label']    = '邮箱';
 $lang['forgot_password_email_not_found']         = '无此邮箱的记录.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = '修改密码';

--- a/language/zh_tw/auth_lang.php
+++ b/language/zh_tw/auth_lang.php
@@ -140,6 +140,7 @@ $lang['forgot_password_validation_email_label']  = '電子郵件';
 $lang['forgot_password_username_identity_label'] = '帳號';
 $lang['forgot_password_email_identity_label']    = '電子郵件';
 $lang['forgot_password_email_not_found']         = '找不到此電子郵件相關資訊.';
+$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
 
 // Reset Password
 $lang['reset_password_heading']                               = '修改密碼';


### PR DESCRIPTION
I just translate our language FILIPINO, so the other is just English


[here](https://github.com/benedmunds/CodeIgniter-Ion-Auth/blob/2/controllers/Auth.php#L225) the lang tag that not exist.
```php 
        public function forgot_password()
	{
               .....

               if ( $this->config->item('identity', 'ion_auth') != 'email' ){
		     $this->data['identity_label'] = $this->lang->line('forgot_password_identity_label');
		}
		else
		{
	            $this->data['identity_label'] = $this->lang->line('forgot_password_email_identity_label');
	        }
 ```
