### PR TITLE
access trigger with remember login

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -439,6 +439,10 @@ class Ion_auth
 
                 $recheck= $this->ion_auth_model->recheck_session();
         
+                if(! is_bool($recheck))//check if the return is bool, else mean the recheck check it that need to log out the user
+                {
+                      return FALSE;  
+                }
                 //auto-login the user if they are remembered
                 if ( ! $recheck && get_cookie($this->config->item('identity_cookie_name', 'ion_auth')) && get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
 		{

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -66,13 +66,7 @@ class Ion_auth
 		$this->load->model('ion_auth_model');
 
 		$this->_cache_user_in_group =& $this->ion_auth_model->_cache_user_in_group;
-
-		//auto-login the user if they are remembered
-		if (!$this->logged_in() && get_cookie($this->config->item('identity_cookie_name', 'ion_auth')) && get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
-		{
-			$this->ion_auth_model->login_remembered_user();
-		}
-
+	
 		$email_config = $this->config->item('email_config', 'ion_auth');
 
 		if ($this->config->item('use_ci_email', 'ion_auth') && isset($email_config) && is_array($email_config))
@@ -443,7 +437,15 @@ class Ion_auth
 	{
 		$this->ion_auth_model->trigger_events('logged_in');
 
-        return $this->ion_auth_model->recheck_session();
+                $recheck= $this->ion_auth_model->recheck_session();
+        
+                //auto-login the user if they are remembered
+                if ( ! $recheck && get_cookie($this->config->item('identity_cookie_name', 'ion_auth')) && get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
+		{
+			$recheck = $this->ion_auth_model->login_remembered_user();
+		}
+                
+                return $recheck;
 	}
 
 	/**

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -66,7 +66,13 @@ class Ion_auth
 		$this->load->model('ion_auth_model');
 
 		$this->_cache_user_in_group =& $this->ion_auth_model->_cache_user_in_group;
-	
+
+		//auto-login the user if they are remembered
+//		if (!$this->logged_in() && get_cookie($this->config->item('identity_cookie_name', 'ion_auth')) && get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
+//		{
+//			$this->ion_auth_model->login_remembered_user();
+//		}
+
 		$email_config = $this->config->item('email_config', 'ion_auth');
 
 		if ($this->config->item('use_ci_email', 'ion_auth') && isset($email_config) && is_array($email_config))
@@ -437,19 +443,24 @@ class Ion_auth
 	{
 		$this->ion_auth_model->trigger_events('logged_in');
 
-                $recheck= $this->ion_auth_model->recheck_session();
+                $sesson_identity=(bool) $this->session->userdata('identity');
         
-                if(! is_bool($recheck))//check if the return is bool, else mean the recheck check it that need to log out the user
-                {
-                      return FALSE;  
-                }
                 //auto-login the user if they are remembered
-                if ( ! $recheck && get_cookie($this->config->item('identity_cookie_name', 'ion_auth')) && get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
+                if ( ! $sesson_identity && get_cookie($this->config->item('identity_cookie_name', 'ion_auth')) && get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
 		{
-			$recheck = $this->ion_auth_model->login_remembered_user();
+			$sesson_identity= $this->ion_auth_model->login_remembered_user();
 		}
+               
+                /**
+                 * just log out the user if detect -1 
+                 */
+                if($this->ion_auth_model->recheck_session() === -1)
+                {
+                        
+                        return FALSE;
+                }
                 
-                return $recheck;
+                return $sesson_identity;
 	}
 
 	/**

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1046,7 +1046,15 @@ class Ion_auth_model extends CI_Model
         if($recheck!==0)
         {
             $last_login = $this->session->userdata('last_check');
-            if($last_login+$recheck < time())
+                
+            if (get_cookie($this->config->item('identity_cookie_name', 'ion_auth')) && get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
+            {
+	       //if remembered-login,then just the session lastlogin will used, because session is refresh by remember-user
+	    }else{
+                    $last_login+=$recheck ;
+            }
+           
+            if($last_login < time())
             {
                 $query = $this->db->select('id')
                     ->where(array($this->identity_column=>$this->session->userdata('identity'),'active'=>'1'))
@@ -1071,7 +1079,7 @@ class Ion_auth_model extends CI_Model
                     {
                         $this->session->unset_userdata( array($identity, 'id', 'user_id') );
                     }
-                    return -1;//to  know the return FALSE is the recheck  function not from session expire
+                      return -1;//to  know the return FALSE is the recheck  function not from session expire
                 }
             }
         }

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1071,7 +1071,7 @@ class Ion_auth_model extends CI_Model
                     {
                         $this->session->unset_userdata( array($identity, 'id', 'user_id') );
                     }
-                    return false;
+                    return -1;//to  know the return FALSE is the recheck  function not from session expire
                 }
             }
         }


### PR DESCRIPTION
this can be resolve issue #1075 ,

Ive noticed that checking remember is on `contruct`, then i see it also check  `logged_in` ,

so i decide to combine the function `logged_in` and the checking `remember`.

so `ion auth `can load entire file before check if `remeber` login