### PR TITLE
Let's make sure the user it's active

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1861,6 +1861,7 @@ class Ion_auth_model extends CI_Model
 		$query = $this->db->select($this->identity_column.', id, email, last_login')
 		                  ->where($this->identity_column, urldecode(get_cookie($this->config->item('identity_cookie_name', 'ion_auth'))))
 		                  ->where('remember_code', get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
+				  ->where('active','1')
 		                  ->limit(1)
 		    			  ->order_by('id', 'desc')
 		                  ->get($this->tables['users']);

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1861,7 +1861,7 @@ class Ion_auth_model extends CI_Model
 		$query = $this->db->select($this->identity_column.', id, email, last_login')
 		                  ->where($this->identity_column, urldecode(get_cookie($this->config->item('identity_cookie_name', 'ion_auth'))))
 		                  ->where('remember_code', get_cookie($this->config->item('remember_cookie_name', 'ion_auth')))
-				  ->where('active','1')
+				  ->where('active',1)
 		                  ->limit(1)
 		    			  ->order_by('id', 'desc')
 		                  ->get($this->tables['users']);


### PR DESCRIPTION
If we want to login a remembered user, we should also make sure that the user is active. This should address the problem reported by @lloricode in PR #1078.