### PR TITLE
Fix Bug #1091 : Add the name of the sequence for insert_id method

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -932,7 +932,7 @@ class Ion_auth_model extends CI_Model
 
 		$this->db->insert($this->tables['users'], $user_data);
 
-		$id = $this->db->insert_id();
+		$id = $this->db->insert_id($this->tables['users'] . '_id_seq');
 
 		// add in groups array if it doesn't exists and stop adding into default group if default group ids are set
 		if( isset($default_group->id) && empty($groups) )
@@ -1922,7 +1922,7 @@ class Ion_auth_model extends CI_Model
 
 		// insert the new group
 		$this->db->insert($this->tables['groups'], $data);
-		$group_id = $this->db->insert_id();
+		$group_id = $this->db->insert_id($this->tables['groups'] . '_id_seq');
 
 		// report success
 		$this->set_message('group_creation_successful');


### PR DESCRIPTION
I only set the name of the sequence for Postgres database.

For IBase (which I nerver use), I don't know the default name of the sequence, It is possible to use a if statement with $this->db->dbdriver (pdo or ibase) and/or  $this->db->subdriver (pgsql) to determine the database and set the argument with the good value. But, I twonder if some people really use it with Ion_Auth.

For other db, this PR doesn't change anything (I test it with pdo_mysql) : the argument passed to insert_id is ignored.