### PR TITLE
Consistent identity/IP address checks for login attempts

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1109,10 +1109,10 @@ class Ion_auth_model extends CI_Model
         if ($this->config->item('track_login_attempts', 'ion_auth')) {
             $ip_address = $this->_prepare_ip($this->input->ip_address());
             $this->db->select('1', FALSE);
+            $this->db->where('login', $identity);
             if ($this->config->item('track_login_ip_address', 'ion_auth')) {
             	$this->db->where('ip_address', $ip_address);
-            	$this->db->where('login', $identity);
-            } else if (strlen($identity) > 0) $this->db->or_where('login', $identity);
+            }
             $qres = $this->db->get($this->tables['login_attempts']);
             return $qres->num_rows();
         }
@@ -1141,8 +1141,10 @@ class Ion_auth_model extends CI_Model
 			$ip_address = $this->_prepare_ip($this->input->ip_address());
 
 			$this->db->select('time');
-            if ($this->config->item('track_login_ip_address', 'ion_auth')) $this->db->where('ip_address', $ip_address);
-			else if (strlen($identity) > 0) $this->db->or_where('login', $identity);
+			$this->db->where('login', $identity);
+			if ($this->config->item('track_login_ip_address', 'ion_auth')) {
+				$this->db->where('ip_address', $ip_address);
+			}
 			$this->db->order_by('id', 'desc');
 			$qres = $this->db->get($this->tables['login_attempts'], 1);
 


### PR DESCRIPTION
**Former (not consistent) behavior:**
1. `get_attempts_num()` checks:
    - IP address and identity, if `track_login_ip_address` is set
    - Identity, if it is not an empty string
2. `get_last_attempt_time()` checks:
    - IP address, if `track_login_ip_address` is set
    - Identity, if it is not an empty string

Note: in the second function, the identity was not checked if IP was tracked.

**Proposed (consistent) behavior:**
1. `get_attempts_num()` and `get_last_attempt_time()` check:
    - Identity
    - IP address, if `track_login_ip_address` is set

Identity is always checked. I can't imagine a case where this would be empty.
IP Address is checked if option is activated.
