### PR TITLE
Use timestamp when retrieving the number of attempts

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -94,10 +94,11 @@ $config['manual_activation']          = FALSE;               // Manual Activatio
 $config['remember_users']             = TRUE;                // Allow users to be remembered and enable auto-login
 $config['user_expire']                = 86500;               // How long to remember the user (seconds). Set to zero for no expiration
 $config['user_extend_on_login']       = FALSE;               // Extend the users cookies every time they auto-login
-$config['track_login_attempts']       = FALSE;               // Track the number of failed login attempts for each user or ip.
+$config['track_login_attempts']       = TRUE;                // Track the number of failed login attempts for each user or ip.
 $config['track_login_ip_address']     = TRUE;                // Track login attempts by IP Address, if FALSE will track based on identity. (Default: TRUE)
 $config['maximum_login_attempts']     = 3;                   // The maximum number of failed login attempts.
-$config['lockout_time']               = 600;                 // The number of seconds to lockout an account due to exceeded attempts
+$config['lockout_time']               = 600;                 /* The number of seconds to lockout an account due to exceeded attempts
+							        You should not use a value below 60 (1 minute) */
 $config['forgot_password_expiration'] = 0;                   // The number of milliseconds after which a forgot password request will expire. If set to 0, forgot password requests will not expire.
 $config['recheck_timer']              = 0;                   /* The number of seconds after which the session is checked again against database to see if the user still exists and is active.
 							           Leave 0 if you don't want session recheck. if you really think you need to recheck the session against database, we would

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -978,7 +978,7 @@ class Ion_auth_model extends CI_Model
 		    			  ->order_by('id', 'desc')
 		                  ->get($this->tables['users']);
 
-		if($this->is_time_locked_out($identity))
+		if($this->is_max_login_attempts_exceeded($identity))
 		{
 			// Hash something anyway, just to take up time
 			$this->hash_password($password);
@@ -1113,6 +1113,7 @@ class Ion_auth_model extends CI_Model
             if ($this->config->item('track_login_ip_address', 'ion_auth')) {
             	$this->db->where('ip_address', $ip_address);
             }
+            $this->db->where('time >', time() - $this->config->item('lockout_time', 'ion_auth'), FALSE);
             $qres = $this->db->get($this->tables['login_attempts']);
             return $qres->num_rows();
         }
@@ -1123,15 +1124,22 @@ class Ion_auth_model extends CI_Model
 	 * Get a boolean to determine if an account should be locked out due to
 	 * exceeded login attempts within a given period
 	 *
+	 * This function is only a wrapper for is_max_login_attempts_exceeded() since it
+	 * only retrieve attempts within the given period.
+	 * It is kept for retrocompatibility purpose.
+	 *
+	 * @param	string $identity
 	 * @return	boolean
 	 */
 	public function is_time_locked_out($identity) {
-
-		return $this->is_max_login_attempts_exceeded($identity) && $this->get_last_attempt_time($identity) > time() - $this->config->item('lockout_time', 'ion_auth');
+		return $this->is_max_login_attempts_exceeded($identity);
 	}
 
 	/**
 	 * Get the time of the last time a login attempt occured from given IP-address or identity
+	 *
+	 * This function is no longer used.
+	 * It is kept for retrocompatibility purpose.
 	 *
 	 * @param	string $identity
 	 * @return	int


### PR DESCRIPTION
As discussed in #1094.

The principal modification concerns the `get_attempts_num()` function, which now filter by timestamp value as well.
The nice thing is that `is_time_locked_out()` function is now redundant since the number of attempts will already take into accounts the lockout_time.
Hence, we could actually remove `is_time_locked_out()` as well as `get_last_attempt_time()` (which was made only for this). However, we keep them for retrocompatibility purpose, as some user may rely on them. 

The `clear_login_attempts()` function is updated as well to make sure the expire period value, used to remove older attempts, is not set smaller than the lockout_time configuration value as this would be a security flaw.