### PR TITLE
Stop truncating IPv6 addresses, bumped max email char limit & other migration tweaks

### DIFF
--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -1,17 +1,21 @@
 <?php defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Migration_Install_ion_auth extends CI_Migration {
+	private $tables;
 
 	public function __construct()
 	{
 		parent::__construct();
 		$this->load->dbforge();
+
+		$this->load->config('ion_auth', TRUE);
+		$this->tables = $this->config->item('tables', 'ion_auth');
 	}
 
 	public function up()
 	{
 		// Drop table 'groups' if it exists
-		$this->dbforge->drop_table('groups', TRUE);
+		$this->dbforge->drop_table($this->tables['groups'], TRUE);
 
 		// Table structure for table 'groups'
 		$this->dbforge->add_field(array(
@@ -31,7 +35,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 			)
 		));
 		$this->dbforge->add_key('id', TRUE);
-		$this->dbforge->create_table('groups');
+		$this->dbforge->create_table($this->tables['groups']);
 
 		// Dumping data for table 'groups'
 		$data = array(
@@ -46,11 +50,11 @@ class Migration_Install_ion_auth extends CI_Migration {
 				'description' => 'General User'
 			)
 		);
-		$this->db->insert_batch('groups', $data);
+		$this->db->insert_batch($this->tables['groups'], $data);
 
 
 		// Drop table 'users' if it exists
-		$this->dbforge->drop_table('users', TRUE);
+		$this->dbforge->drop_table($this->tables['users'], TRUE);
 
 		// Table structure for table 'users'
 		$this->dbforge->add_field(array(
@@ -141,7 +145,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 
 		));
 		$this->dbforge->add_key('id', TRUE);
-		$this->dbforge->create_table('users');
+		$this->dbforge->create_table($this->tables['users']);
 
 		// Dumping data for table 'users'
 		$data = array(
@@ -161,11 +165,11 @@ class Migration_Install_ion_auth extends CI_Migration {
 			'company' => 'ADMIN',
 			'phone' => '0',
 		);
-		$this->db->insert('users', $data);
+		$this->db->insert($this->tables['users'], $data);
 
 
 		// Drop table 'users_groups' if it exists
-		$this->dbforge->drop_table('users_groups', TRUE);
+		$this->dbforge->drop_table($this->tables['users_groups'], TRUE);
 
 		// Table structure for table 'users_groups'
 		$this->dbforge->add_field(array(
@@ -187,7 +191,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 			)
 		));
 		$this->dbforge->add_key('id', TRUE);
-		$this->dbforge->create_table('users_groups');
+		$this->dbforge->create_table($this->tables['users_groups']);
 
 		// Dumping data for table 'users_groups'
 		$data = array(
@@ -202,11 +206,11 @@ class Migration_Install_ion_auth extends CI_Migration {
 				'group_id' => '2',
 			)
 		);
-		$this->db->insert_batch('users_groups', $data);
+		$this->db->insert_batch($this->tables['users_groups'], $data);
 
 
 		// Drop table 'login_attempts' if it exists
-		$this->dbforge->drop_table('login_attempts', TRUE);
+		$this->dbforge->drop_table($this->tables['login_attempts'], TRUE);
 
 		// Table structure for table 'login_attempts'
 		$this->dbforge->add_field(array(
@@ -233,15 +237,15 @@ class Migration_Install_ion_auth extends CI_Migration {
 			)
 		));
 		$this->dbforge->add_key('id', TRUE);
-		$this->dbforge->create_table('login_attempts');
+		$this->dbforge->create_table($this->tables['login_attempts']);
 
 	}
 
 	public function down()
 	{
-		$this->dbforge->drop_table('users', TRUE);
-		$this->dbforge->drop_table('groups', TRUE);
-		$this->dbforge->drop_table('users_groups', TRUE);
-		$this->dbforge->drop_table('login_attempts', TRUE);
+		$this->dbforge->drop_table($this->tables['users'], TRUE);
+		$this->dbforge->drop_table($this->tables['groups'], TRUE);
+		$this->dbforge->drop_table($this->tables['users_groups'], TRUE);
+		$this->dbforge->drop_table($this->tables['login_attempts'], TRUE);
 	}
 }

--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -2,6 +2,12 @@
 
 class Migration_Install_ion_auth extends CI_Migration {
 
+	public function __construct()
+	{
+		parent::__construct();
+		$this->load->dbforge();
+	}
+
 	public function up()
 	{
 		// Drop table 'groups' if it exists

--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -50,7 +50,6 @@ class Migration_Install_ion_auth extends CI_Migration {
 		);
 		$this->db->insert_batch($this->tables['groups'], $data);
 
-
 		// Drop table 'users' if it exists
 		$this->dbforge->drop_table($this->tables['users'], TRUE);
 
@@ -76,7 +75,8 @@ class Migration_Install_ion_auth extends CI_Migration {
 			),
 			'salt' => array(
 				'type'       => 'VARCHAR',
-				'constraint' => '40'
+				'constraint' => '40',
+				'null'       => TRUE
 			),
 			'email' => array(
 				'type'       => 'VARCHAR',

--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -63,7 +63,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 			),
 			'ip_address' => array(
 				'type'       => 'VARCHAR',
-				'constraint' => '16'
+				'constraint' => '45'
 			),
 			'username' => array(
 				'type'       => 'VARCHAR',
@@ -220,7 +220,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 			),
 			'ip_address' => array(
 				'type'       => 'VARCHAR',
-				'constraint' => '16'
+				'constraint' => '45'
 			),
 			'login' => array(
 				'type'       => 'VARCHAR',

--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -3,8 +3,7 @@
 class Migration_Install_ion_auth extends CI_Migration {
 	private $tables;
 
-	public function __construct()
-	{
+	public function __construct() {
 		parent::__construct();
 		$this->load->dbforge();
 
@@ -12,25 +11,24 @@ class Migration_Install_ion_auth extends CI_Migration {
 		$this->tables = $this->config->item('tables', 'ion_auth');
 	}
 
-	public function up()
-	{
+	public function up() {
 		// Drop table 'groups' if it exists
 		$this->dbforge->drop_table($this->tables['groups'], TRUE);
 
 		// Table structure for table 'groups'
 		$this->dbforge->add_field(array(
 			'id' => array(
-				'type' => 'MEDIUMINT',
-				'constraint' => '8',
-				'unsigned' => TRUE,
+				'type'           => 'MEDIUMINT',
+				'constraint'     => '8',
+				'unsigned'       => TRUE,
 				'auto_increment' => TRUE
 			),
 			'name' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '20',
 			),
 			'description' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '100',
 			)
 		));
@@ -40,13 +38,13 @@ class Migration_Install_ion_auth extends CI_Migration {
 		// Dumping data for table 'groups'
 		$data = array(
 			array(
-				'id' => '1',
-				'name' => 'admin',
+				'id'          => '1',
+				'name'        => 'admin',
 				'description' => 'Administrator'
 			),
 			array(
-				'id' => '2',
-				'name' => 'members',
+				'id'          => '2',
+				'name'        => 'members',
 				'description' => 'General User'
 			)
 		);
@@ -59,88 +57,88 @@ class Migration_Install_ion_auth extends CI_Migration {
 		// Table structure for table 'users'
 		$this->dbforge->add_field(array(
 			'id' => array(
-				'type' => 'MEDIUMINT',
-				'constraint' => '8',
-				'unsigned' => TRUE,
+				'type'           => 'MEDIUMINT',
+				'constraint'     => '8',
+				'unsigned'       => TRUE,
 				'auto_increment' => TRUE
 			),
 			'ip_address' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '16'
 			),
 			'username' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '100',
 			),
 			'password' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '80',
 			),
 			'salt' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '40'
 			),
 			'email' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '100'
 			),
 			'activation_code' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '40',
-				'null' => TRUE
+				'null'       => TRUE
 			),
 			'forgotten_password_code' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '40',
-				'null' => TRUE
+				'null'       => TRUE
 			),
 			'forgotten_password_time' => array(
-				'type' => 'INT',
+				'type'       => 'INT',
 				'constraint' => '11',
-				'unsigned' => TRUE,
-				'null' => TRUE
+				'unsigned'   => TRUE,
+				'null'       => TRUE
 			),
 			'remember_code' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '40',
-				'null' => TRUE
+				'null'       => TRUE
 			),
 			'created_on' => array(
-				'type' => 'INT',
+				'type'       => 'INT',
 				'constraint' => '11',
-				'unsigned' => TRUE,
+				'unsigned'   => TRUE,
 			),
 			'last_login' => array(
-				'type' => 'INT',
+				'type'       => 'INT',
 				'constraint' => '11',
-				'unsigned' => TRUE,
-				'null' => TRUE
+				'unsigned'   => TRUE,
+				'null'       => TRUE
 			),
 			'active' => array(
-				'type' => 'TINYINT',
+				'type'       => 'TINYINT',
 				'constraint' => '1',
-				'unsigned' => TRUE,
-				'null' => TRUE
+				'unsigned'   => TRUE,
+				'null'       => TRUE
 			),
 			'first_name' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '50',
-				'null' => TRUE
+				'null'       => TRUE
 			),
 			'last_name' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '50',
-				'null' => TRUE
+				'null'       => TRUE
 			),
 			'company' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '100',
-				'null' => TRUE
+				'null'       => TRUE
 			),
 			'phone' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '20',
-				'null' => TRUE
+				'null'       => TRUE
 			)
 
 		));
@@ -149,21 +147,21 @@ class Migration_Install_ion_auth extends CI_Migration {
 
 		// Dumping data for table 'users'
 		$data = array(
-			'id' => '1',
-			'ip_address' => '127.0.0.1',
-			'username' => 'administrator',
-			'password' => '$2a$07$SeBknntpZror9uyftVopmu61qg0ms8Qv1yV6FG.kQOSM.9QhmTo36',
-			'salt' => '',
-			'email' => 'admin@admin.com',
-			'activation_code' => '',
+			'id'                      => '1',
+			'ip_address'              => '127.0.0.1',
+			'username'                => 'administrator',
+			'password'                => '$2a$07$SeBknntpZror9uyftVopmu61qg0ms8Qv1yV6FG.kQOSM.9QhmTo36',
+			'salt'                    => '',
+			'email'                   => 'admin@admin.com',
+			'activation_code'         => '',
 			'forgotten_password_code' => NULL,
-			'created_on' => '1268889823',
-			'last_login' => '1268889823',
-			'active' => '1',
-			'first_name' => 'Admin',
-			'last_name' => 'istrator',
-			'company' => 'ADMIN',
-			'phone' => '0',
+			'created_on'              => '1268889823',
+			'last_login'              => '1268889823',
+			'active'                  => '1',
+			'first_name'              => 'Admin',
+			'last_name'               => 'istrator',
+			'company'                 => 'ADMIN',
+			'phone'                   => '0',
 		);
 		$this->db->insert($this->tables['users'], $data);
 
@@ -174,20 +172,20 @@ class Migration_Install_ion_auth extends CI_Migration {
 		// Table structure for table 'users_groups'
 		$this->dbforge->add_field(array(
 			'id' => array(
-				'type' => 'MEDIUMINT',
-				'constraint' => '8',
-				'unsigned' => TRUE,
+				'type'           => 'MEDIUMINT',
+				'constraint'     => '8',
+				'unsigned'       => TRUE,
 				'auto_increment' => TRUE
 			),
 			'user_id' => array(
-				'type' => 'MEDIUMINT',
+				'type'       => 'MEDIUMINT',
 				'constraint' => '8',
-				'unsigned' => TRUE
+				'unsigned'   => TRUE
 			),
 			'group_id' => array(
-				'type' => 'MEDIUMINT',
+				'type'       => 'MEDIUMINT',
 				'constraint' => '8',
-				'unsigned' => TRUE
+				'unsigned'   => TRUE
 			)
 		));
 		$this->dbforge->add_key('id', TRUE);
@@ -196,13 +194,13 @@ class Migration_Install_ion_auth extends CI_Migration {
 		// Dumping data for table 'users_groups'
 		$data = array(
 			array(
-				'id' => '1',
-				'user_id' => '1',
+				'id'       => '1',
+				'user_id'  => '1',
 				'group_id' => '1',
 			),
 			array(
-				'id' => '2',
-				'user_id' => '1',
+				'id'       => '2',
+				'user_id'  => '1',
 				'group_id' => '2',
 			)
 		);
@@ -215,25 +213,25 @@ class Migration_Install_ion_auth extends CI_Migration {
 		// Table structure for table 'login_attempts'
 		$this->dbforge->add_field(array(
 			'id' => array(
-				'type' => 'MEDIUMINT',
-				'constraint' => '8',
-				'unsigned' => TRUE,
+				'type'           => 'MEDIUMINT',
+				'constraint'     => '8',
+				'unsigned'       => TRUE,
 				'auto_increment' => TRUE
 			),
 			'ip_address' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '16'
 			),
 			'login' => array(
-				'type' => 'VARCHAR',
+				'type'       => 'VARCHAR',
 				'constraint' => '100',
-				'null' => TRUE
+				'null'       => TRUE
 			),
 			'time' => array(
-				'type' => 'INT',
+				'type'       => 'INT',
 				'constraint' => '11',
-				'unsigned' => TRUE,
-				'null' => TRUE
+				'unsigned'   => TRUE,
+				'null'       => TRUE
 			)
 		));
 		$this->dbforge->add_key('id', TRUE);
@@ -241,8 +239,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 
 	}
 
-	public function down()
-	{
+	public function down() {
 		$this->dbforge->drop_table($this->tables['users'], TRUE);
 		$this->dbforge->drop_table($this->tables['groups'], TRUE);
 		$this->dbforge->drop_table($this->tables['users_groups'], TRUE);

--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -80,7 +80,7 @@ class Migration_Install_ion_auth extends CI_Migration {
 			),
 			'email' => array(
 				'type'       => 'VARCHAR',
-				'constraint' => '100'
+				'constraint' => '254'
 			),
 			'activation_code' => array(
 				'type'       => 'VARCHAR',

--- a/sql/ion_auth.mssql.sql
+++ b/sql/ion_auth.mssql.sql
@@ -60,7 +60,7 @@ SET IDENTITY_INSERT users_groups OFF;
 
 CREATE TABLE login_attempts (
     id int NOT NULL IDENTITY(1,1),
-    ip_address varchar(15),
+    ip_address varchar(45),
     login varchar(100) NOT NULL,
 	time datetime,
   PRIMARY KEY(id),

--- a/sql/ion_auth.mssql.sql
+++ b/sql/ion_auth.mssql.sql
@@ -4,7 +4,7 @@ CREATE TABLE users (
     username varchar(100) NULL,
     password varchar(255) NOT NULL,
     salt varchar(255),
-    email varchar(100) NOT NULL,
+    email varchar(254) NOT NULL,
     activation_code varchar(40),
     forgotten_password_code varchar(40),
     forgotten_password_time int,

--- a/sql/ion_auth.postgre.sql
+++ b/sql/ion_auth.postgre.sql
@@ -56,7 +56,7 @@ INSERT INTO users_groups (user_id, group_id) VALUES
 
 CREATE TABLE "login_attempts" (
     "id" SERIAL NOT NULL,
-    "ip_address" varchar(15),
+    "ip_address" varchar(45),
     "login" varchar(100) NOT NULL,
     "time" int,
   PRIMARY KEY("id"),

--- a/sql/ion_auth.postgre.sql
+++ b/sql/ion_auth.postgre.sql
@@ -4,7 +4,7 @@ CREATE TABLE "users" (
     "username" varchar(100) NULL,
     "password" varchar(255) NOT NULL,
     "salt" varchar(255),
-    "email" varchar(100) NOT NULL,
+    "email" varchar(254) NOT NULL,
     "activation_code" varchar(40),
     "forgotten_password_code" varchar(40),
     "forgotten_password_time" int,

--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -88,7 +88,7 @@ DROP TABLE IF EXISTS `login_attempts`;
 
 CREATE TABLE `login_attempts` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `ip_address` varchar(15) NOT NULL,
+  `ip_address` varchar(45) NOT NULL,
   `login` varchar(100) NOT NULL,
   `time` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`)

--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -33,7 +33,7 @@ CREATE TABLE `users` (
   `username` varchar(100) NULL,
   `password` varchar(255) NOT NULL,
   `salt` varchar(255) DEFAULT NULL,
-  `email` varchar(100) NOT NULL,
+  `email` varchar(254) NOT NULL,
   `activation_code` varchar(40) DEFAULT NULL,
   `forgotten_password_code` varchar(40) DEFAULT NULL,
   `forgotten_password_time` int(11) unsigned DEFAULT NULL,


### PR DESCRIPTION
Few useful tweaks here:
* ip_address columns now have a constraint of 45, as to not truncate IPv6 addresses. (As per: https://stackoverflow.com/a/166157/1168377)
* email constraint has been bumped from 100 to 254, which is the max possible length of an email address (As per: https://stackoverflow.com/a/574698/1168377)
* Various migration tweaks: Config is now used for table names, salt can be null (which is what it already is in the .sql files), make sure dbforge is loaded (as not everybody autoloads it) & some formatting changes for readability.