### PR TITLE
Update on Ion_auth_lang file for show error.

### DIFF
--- a/language/english/ion_auth_lang.php
+++ b/language/english/ion_auth_lang.php
@@ -28,6 +28,7 @@ $lang['password_change_successful']          = 'Password Successfully Changed';
 $lang['password_change_unsuccessful']        = 'Unable to Change Password';
 $lang['forgot_password_successful']          = 'Password Reset Email Sent';
 $lang['forgot_password_unsuccessful']        = 'Unable to email the Reset Password link';
+$lang['password_match_old_unsuccessful']     = 'New Password matched to the Old Password. Please try another';
 
 // Activation
 $lang['activate_successful']                 = 'Account Activated';


### PR DESCRIPTION
Hi, 
I have added  'password_match_old_unsuccessful' error with this message. "New Password matched to the Old Password.Please try another".
While a user is changing the password and if he input new password same as the previous password So he will receive an error message. "New Password matched to the Old Password.Please try another".

Code given below.
$lang['password_match_old_unsuccessful']     = 'New Password matched to the Old Password. Please try another';