### PR TITLE
Security fix: always regenerate session on login

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1065,6 +1065,9 @@ class Ion_auth_model extends CI_Model
 				{
 					$this->remember_user($user->id);
 				}
+                
+				// Regenerate the session (for security purpose: to avoid session fixation)
+				$this->_regenerate_session();
 
 				$this->trigger_events(array('post_login', 'post_login_successful'));
 				$this->set_message('login_successful');
@@ -2113,6 +2116,9 @@ class Ion_auth_model extends CI_Model
 			{
 				$this->remember_user($user->id);
 			}
+            
+			// Regenerate the session (for security purpose: to avoid session fixation)
+			$this->_regenerate_session();
 
 			$this->trigger_events(array('post_login_remembered_user', 'post_login_remembered_user_successful'));
 			return TRUE;
@@ -2588,5 +2594,30 @@ class Ion_auth_model extends CI_Model
 	 */
 	protected function _prepare_ip($ip_address) {
 		return $ip_address;
+	}
+
+	/**
+	 * Regenerate the session without losing any data
+	 *
+	 */
+	protected function _regenerate_session() {
+
+		if (substr(CI_VERSION, 0, 1) == '2')
+		{
+			// Save sess_time_to_update and set it temporarily to 0
+			// This is done in order to forces the sess_update method to regenerate
+			$old_sess_time_to_update = $this->session->sess_time_to_update;
+			$this->session->sess_time_to_update = 0;
+
+			// Call the sess_update method to actually regenerate the session ID
+			$this->session->sess_update();
+
+			// Restore sess_time_to_update
+			$this->session->sess_time_to_update = $old_sess_time_to_update;
+		}
+		else
+		{
+			$this->session->sess_regenerate(FALSE);
+		}
 	}
 }


### PR DESCRIPTION
Hello!

I have an interesting security fix to provide 😺 

When a user log in, the session ID shall always be regenerated to avoid session fixation.

More information here:
https://security.stackexchange.com/questions/1246/session-hijacking-regenerate-session-id
https://en.wikipedia.org/wiki/Session_fixation#Regenerate_SID_on_each_request
https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Renew_the_Session_ID_After_Any_Privilege_Level_Change

When a user log out, IonAuth properly destroys the session and generates it again.
The same shall be done when logging in, but while keeping any data in the session.

Tested and works on CI 3.1.7.
I've included a proper backward-compatible code for CI 2.x, however I don't have any live site to test on.
Solution for session regeneration for CI-2 is a little hacky, but there is no other way to do it unfortunately. The solution was inspired by this SO answer: https://stackoverflow.com/a/16743083/8861729

Thanks again for this great library. Have a nice week.