### PR TITLE
Feature: allow to specify a DB group name

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -22,6 +22,17 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /*
+ | -------------------------------------------------------------------------
+ | Database group name option.
+ | -------------------------------------------------------------------------
+ | Allows to select a specific group for the database connection
+ |
+ | Default is empty: uses default group defined in CI's configuration
+ | (see application/config/database.php, $active_group variable)
+ */
+$config['database_group_name'] = '';
+
+/*
 | -------------------------------------------------------------------------
 | Tables.
 | -------------------------------------------------------------------------

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -168,13 +168,22 @@ class Ion_auth_model extends CI_Model
 	 */
 	protected $_cache_groups = array();
 
+	/**
+	 * Database object
+	 *
+	 * @var object
+	 */
+	protected $db;
+
 	public function __construct()
 	{
-		$this->load->database();
 		$this->config->load('ion_auth', TRUE);
 		$this->load->helper('cookie');
 		$this->load->helper('date');
 		$this->lang->load('ion_auth');
+
+		// initialize the database
+		$this->db = $this->load->database($this->config->item('database_group_name', 'ion_auth'), TRUE, TRUE);
 
 		// initialize db tables data
 		$this->tables = $this->config->item('tables', 'ion_auth');


### PR DESCRIPTION
For one of my project, I have several database connections defined in the `database.php` config file.
The one to use depends on several factors, but it is not unusual to have two or more connections loaded in CI (e.g. the first one is accessible by `$this->db`, and the second one by `$this->db_special`, and so on...).

Unfortunately, IonAuth may not be on the default connection. And I don't have any way to configure it.

Hence this PR. I propose a new option `database_group_name` in which the user can set the DB connection group.
This feature is fully backward compatible. It will work as before in its default configuration.

Under the hood, the `load_database()` call is a bit more complex and directly assign it to a local `$this->db` member (instead of using the one loaded globally). But the nice thing is that no change is needed for existing DB call.

**As an additional benefit**, this PR fix a potential bug in which the user has deactivated the Query Builder option globally (`$query_builder` option in `database.php`). Since IonAuth use it extensively, it would break. However, this feature call the database loader with the `$query_builder` option overrided.