### PR TITLE
Ion Auth 3: remove salt and better token generator

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -153,20 +153,6 @@ $config['email_forgot_password'] = 'forgot_password.tpl.php';
 
 /*
  | -------------------------------------------------------------------------
- | Salt options
- | -------------------------------------------------------------------------
- | salt_length Default: 22
- |
- | store_salt: Should the salt be stored in the database?
- | This will change your password encryption algorithm,
- | default password, 'password', changes to
- | fbaa5e216d163a02ae630ab1a43372635dd374c0 with default salt.
- */
-$config['salt_length'] = 22;
-$config['store_salt']  = FALSE;
-
-/*
- | -------------------------------------------------------------------------
  | Message Delimiters.
  | -------------------------------------------------------------------------
  */

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -488,8 +488,17 @@ class Ion_auth
 		}
 
 		// Sanity check for CI2
-		if (substr(CI_VERSION, 0, 1) === '2') {
+		if (substr(CI_VERSION, 0, 1) === '2')
+		{
 			show_error("Ion Auth 3 requires CodeIgniter 3. Update to CI 3 or downgrade to Ion Auth 2.");
+		}
+
+		// Compatibility check for CSPRNG
+		// See functions used in Ion_auth_model::_random_token()
+		if (!function_exists('random_bytes') && !function_exists('mcrypt_create_iv') && !function_exists('openssl_random_pseudo_bytes'))
+		{
+			show_error("No CSPRNG functions to generate random enough token. " .
+				"Please update to PHP 7 or use random_compat (https://github.com/paragonie/random_compat).");
 		}
 	}
 

--- a/migrations/001_install_ion_auth.php
+++ b/migrations/001_install_ion_auth.php
@@ -71,11 +71,6 @@ class Migration_Install_ion_auth extends CI_Migration {
 				'type'       => 'VARCHAR',
 				'constraint' => '80',
 			),
-			'salt' => array(
-				'type'       => 'VARCHAR',
-				'constraint' => '40',
-				'null'       => TRUE
-			),
 			'email' => array(
 				'type'       => 'VARCHAR',
 				'constraint' => '254'
@@ -148,7 +143,6 @@ class Migration_Install_ion_auth extends CI_Migration {
 			'ip_address'              => '127.0.0.1',
 			'username'                => 'administrator',
 			'password'                => '$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa',
-			'salt'                    => '',
 			'email'                   => 'admin@admin.com',
 			'activation_code'         => '',
 			'forgotten_password_code' => NULL,

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -2367,7 +2367,6 @@ class Ion_auth_model extends CI_Model
 		}
 
 		// No luck!
-		show_error("Cannot generate a token random enough. " .
-					"Please update to PHP 7 or use random_compat (https://github.com/paragonie/random_compat).");
+		return FALSE;
 	}
 }

--- a/sql/ion_auth.mssql.sql
+++ b/sql/ion_auth.mssql.sql
@@ -3,7 +3,6 @@ CREATE TABLE users (
     ip_address varchar(45) NOT NULL,
     username varchar(100) NULL,
     password varchar(255) NOT NULL,
-    salt varchar(255),
     email varchar(254) NOT NULL,
     activation_code varchar(40),
     forgotten_password_code varchar(40),
@@ -49,8 +48,8 @@ INSERT INTO groups (id, name, description) VALUES (2,'members','General User');
 SET IDENTITY_INSERT groups OFF;
 
 SET IDENTITY_INSERT users ON;
-INSERT INTO users (id, ip_address, username, password, salt, email, activation_code, forgotten_password_code, created_on, last_login, active, first_name, last_name, company, phone)
-	VALUES ('1','127.0.0.1','administrator','$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa','','admin@admin.com','',NULL, DATEDIFF(s, '19700101', GETDATE()), DATEDIFF(s, '19700101', GETDATE()),'1','Admin','istrator','ADMIN','0');
+INSERT INTO users (id, ip_address, username, password, email, activation_code, forgotten_password_code, created_on, last_login, active, first_name, last_name, company, phone)
+	VALUES ('1','127.0.0.1','administrator','$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa','admin@admin.com','',NULL, DATEDIFF(s, '19700101', GETDATE()), DATEDIFF(s, '19700101', GETDATE()),'1','Admin','istrator','ADMIN','0');
 SET IDENTITY_INSERT users OFF;
 
 SET IDENTITY_INSERT users_groups ON;

--- a/sql/ion_auth.postgre.sql
+++ b/sql/ion_auth.postgre.sql
@@ -3,7 +3,6 @@ CREATE TABLE "users" (
     "ip_address" varchar(45),
     "username" varchar(100) NULL,
     "password" varchar(255) NOT NULL,
-    "salt" varchar(255),
     "email" varchar(254) NOT NULL,
     "activation_code" varchar(40),
     "forgotten_password_code" varchar(40),
@@ -47,8 +46,8 @@ INSERT INTO groups (id, name, description) VALUES
     (1,'admin','Administrator'),
     (2,'members','General User');
 
-INSERT INTO users (ip_address, username, password, salt, email, activation_code, forgotten_password_code, created_on, last_login, active, first_name, last_name, company, phone) VALUES
-    ('127.0.0.1','administrator','$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa','','admin@admin.com','',NULL,'1268889823','1268889823','1','Admin','istrator','ADMIN','0');
+INSERT INTO users (ip_address, username, password, email, activation_code, forgotten_password_code, created_on, last_login, active, first_name, last_name, company, phone) VALUES
+    ('127.0.0.1','administrator','$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa','admin@admin.com','',NULL,'1268889823','1268889823','1','Admin','istrator','ADMIN','0');
 
 INSERT INTO users_groups (user_id, group_id) VALUES
     (1,1),

--- a/sql/ion_auth.sql
+++ b/sql/ion_auth.sql
@@ -32,7 +32,6 @@ CREATE TABLE `users` (
   `ip_address` varchar(45) NOT NULL,
   `username` varchar(100) NULL,
   `password` varchar(255) NOT NULL,
-  `salt` varchar(255) DEFAULT NULL,
   `email` varchar(254) NOT NULL,
   `activation_code` varchar(40) DEFAULT NULL,
   `forgotten_password_code` varchar(40) DEFAULT NULL,
@@ -53,8 +52,8 @@ CREATE TABLE `users` (
 # Dumping data for table 'users'
 #
 
-INSERT INTO `users` (`id`, `ip_address`, `username`, `password`, `salt`, `email`, `activation_code`, `forgotten_password_code`, `created_on`, `last_login`, `active`, `first_name`, `last_name`, `company`, `phone`) VALUES
-     ('1','127.0.0.1','administrator','$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa','','admin@admin.com','',NULL,'1268889823','1268889823','1', 'Admin','istrator','ADMIN','0');
+INSERT INTO `users` (`id`, `ip_address`, `username`, `password`, `email`, `activation_code`, `forgotten_password_code`, `created_on`, `last_login`, `active`, `first_name`, `last_name`, `company`, `phone`) VALUES
+     ('1','127.0.0.1','administrator','$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa','admin@admin.com','',NULL,'1268889823','1268889823','1', 'Admin','istrator','ADMIN','0');
 
 
 DROP TABLE IF EXISTS `users_groups`;

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -187,8 +187,6 @@ Documentation
 		<li>$config['email_templates']</li>
 		<li>$config['email_activate']</li>
 		<li>$config['email_forgot_password']</li>
-		<li>$config['salt_length']</li>
-		<li>$config['store_salt'] </li>
 		<li>$config['forgot_password_expiration'] </li>
 		<li>$config['track_login_attempts'] </li>
 		<li>$config['maximum_login_attempts'] </li>
@@ -229,8 +227,6 @@ Documentation
 		<li>'email_templates' -  Folder where the email view templates are stored. DEFAULT is 'auth/email/'.</li>
 		<li>'email_activate' -  Filname of the email activation view template. DEFAULT is 'activate.tpl.php'.</li>
 		<li>'email_forgot_password' -  Filname of the forgot password email view template. DEFAULT is 'forgot_password.tpl.php'.</li>
-		<li>'salt_length' -  Length of the encryption salt. DEFAULT is '10'.</li>
-		<li>'store_salt' -  TRUE or FALSE.  Store the salt in a separate database column or not. This can be useful for integrating with existing apps. DEFAULT is 'false'.</li>
 		<li>'forgot_password_expiration' - Number of seconds before a forgot password request expires. If set to 0, requests will not expire. DEFAULT is 0.</li>
 		<li>'track_login_attempts' - Track the number of failed login attempts for each user or ip. DEFAULT is 'false'.</li>
 		<li>'maximum_login_attempts' - Set the maximum number of failed login attempts. This maximum is not enforced by the library, but is
@@ -765,7 +761,6 @@ Documentation
 				[ip_address] => 127.0.0.1
 				[username] => administrator
 				[password] => 59beecdf7fc966e2f17fd8f65a4a9aeb09d4a3d4
-				[salt] => 9462e8eee0
 				[email] => admin@admin.com
 				[activation_code] => 19e181f2ccc2a7ea58a2c0aa2b69f4355e636ef4
 				[forgotten_password_code] => 81dce1d0bc2c10fbdec7a87f1ff299ed7e4c9e4a


### PR DESCRIPTION
Related to #1195 

Since bcrypt handles the salt internally, there is no need to store it separately.

This PR removes any salt-related code.

Also, the salt generator was used to generate the remember and forgotten token.
We greatly simplify it by using a simple `random_token()` generator based on function known to be random enough. In case a user misses the proper function (I would guess less than 1%), then the [random_compat](https://github.com/paragonie/random_compat) library is proposed.
