### PR TITLE
Ion Auth 3: handle legacy SHA1 password

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -275,13 +275,13 @@ class Ion_auth_model extends CI_Model
 	 * This function takes a password and validates it
 	 * against an entry in the users table.
 	 *
-	 * @param string|int $id
-	 * @param string     $password
+	 * @param string	$identity
+	 * @param string	$password
 	 *
 	 * @return bool
 	 * @author Mathew
 	 */
-	public function hash_password_db($id, $password)
+	public function hash_password_db($identity, $password)
 	{
 		// Check for empty id or password, or password containing null char
 		// Null char may pose issue: http://php.net/manual/en/function.password-hash.php#118603
@@ -293,7 +293,7 @@ class Ion_auth_model extends CI_Model
 		$this->trigger_events('extra_where');
 
 		$query = $this->db->select('password')
-		                  ->where('id', $id)
+		                  ->where($this->identity_column, $identity)
 		                  ->limit(1)
 		                  ->order_by('id', 'desc')
 		                  ->get($this->tables['users']);
@@ -556,7 +556,7 @@ class Ion_auth_model extends CI_Model
 
 		$user = $query->row();
 
-		if ($this->hash_password_db($user->id, $old))
+		if ($this->hash_password_db($identity, $old))
 		{
 			$result = $this->_set_password_db($identity, $new);
 
@@ -832,7 +832,7 @@ class Ion_auth_model extends CI_Model
 		{
 			$user = $query->row();
 
-			$password = $this->hash_password_db($user->id, $password);
+			$password = $this->hash_password_db($identity, $password);
 
 			if ($password === TRUE)
 			{


### PR DESCRIPTION
As #1195 

First `hash_password_db()` uses the identity column instead of ID (so we can pass around the $identity variable without calling the DB).

Secondly, `hash_password_db()` will detect a SHA1 stored password (i.e. not starting with `$`), and run the specific function `_password_verify_sha1_legacy()`.

This function re-implements how the SHA1 algorithm was being set (with the salting).
If the match if successful, then the password is set to use the newest algorithm (just like `password_needs_rehash` actually).

Hope I didn't miss anything. Some test will be needed of course.