### PR TITLE
Ion Auth 3 : implements different hashing params for administrators

### DIFF
--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -73,8 +73,11 @@ $config['join']['groups'] = 'group_id';
  | 		With bcrypt, an example hash of "password" is:
  | 		$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa
  |
+ |		A specific parameter bcrypt_admin_cost is available for user in admin group.
+ |		It is recommended to have a stronger hashing for administrators.
+ |
  | Argon2 specific:
- | 		argon2_parameters settings:  This is an array containing the options for the Argon2 algorithm.
+ | 		argon2_default_params settings:  This is an array containing the options for the Argon2 algorithm.
  | 		You can define 3 differents keys:
  | 			memory_cost (default PASSWORD_ARGON2_DEFAULT_MEMORY_COST = 1024)
  |				Maximum memory (in kBytes) that may be used to compute the Argon2 hash
@@ -91,17 +94,24 @@ $config['join']['groups'] = 'group_id';
  | 		With argon2, an example hash of "password" is:
  | 		$argon2i$v=19$m=1024,t=2,p=2$VEFSSU4wSzh3cllVdE1JZQ$PDeks/7JoKekQrJa9HlfkXIk8dAeZXOzUxLBwNFbZ44
  |
+ |		A specific parameter argon2_admin_params is available for user in admin group.
+ |		It is recommended to have a stronger hashing for administrators.
  |
  | For more information, check the password_hash function help: http://php.net/manual/en/function.password-hash.php
  |
  */
-$config['hash_method']    		= 'bcrypt';	// bcrypt or argon2
-$config['bcrypt_default_cost']	= 9;		// Set cost according to your server benchmark
-$config['argon2_parameters']	= array(
-	// Uncomment param to set a specific value as needed
-	// 'memory_cost' 	=> PASSWORD_ARGON2_DEFAULT_MEMORY_COST,
-	// 'time_cost'  	=> PASSWORD_ARGON2_DEFAULT_TIME_COST,
-	// 'threads'  		=> PASSWORD_ARGON2_DEFAULT_THREADS
+$config['hash_method']				= 'bcrypt';	// bcrypt or argon2
+$config['bcrypt_default_cost']		= 10;		// Set cost according to your server benchmark - but no lower than 10 (default PHP value)
+$config['bcrypt_admin_cost']		= 12;		// Cost for user in admin group
+$config['argon2_default_params']	= array(
+	'memory_cost'	=> 1 << 12,	// 4MB
+	'time_cost'		=> 2,
+	'threads'		=> 2
+);
+$config['argon2_admin_params']		= array(
+	'memory_cost'	=> 1 << 14,	// 16MB
+	'time_cost'		=> 4,
+	'threads'		=> 2
 );
 
 /*

--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -70,21 +70,26 @@ $config['join']['groups'] = 'group_id';
  | 		You can (and should!) benchmark your server. This can be done easily with this little script:
  | 		https://gist.github.com/Indigo744/24062e07477e937a279bc97b378c3402
  |
- | 		With bcrypt, the "password" password is:
+ | 		With bcrypt, an example hash of "password" is:
  | 		$2y$08$200Z6ZZbp3RAEXoaWcMA6uJOFicwNZaqk4oDhqTUiFXFe63MG.Daa
  |
  | Argon2 specific:
  | 		argon2_parameters settings:  This is an array containing the options for the Argon2 algorithm.
  | 		You can define 3 differents keys:
  | 			memory_cost (default PASSWORD_ARGON2_DEFAULT_MEMORY_COST = 1024)
- |				Maximum memory (in bytes) that may be used to compute the Argon2 hash
+ |				Maximum memory (in kBytes) that may be used to compute the Argon2 hash
+ |				The spec recommends setting the memory cost to a power of 2.
  | 			time_cost (default PASSWORD_ARGON2_DEFAULT_TIME_COST = 2 seconds)
  |				Maximum amount of time (in seconds) it may take to compute the Argon2 hash
  | 			threads (default PASSWORD_ARGON2_DEFAULT_THREADS = 2)
  |				Number of threads to use for computing the Argon2 hash
+ |				The spec recommends setting the number of threads to a power of 2.
  |
- | 		There is actually no need with Argon2 to benchmark your server since you can clearly define the
- | 		time cost of the algorithm.
+ | 		You can (and should!) benchmark your server. This can be done easily with this little script:
+ | 		https://gist.github.com/Indigo744/e92356282eb808b94d08d9cc6e37884c
+ |
+ | 		With argon2, an example hash of "password" is:
+ | 		$argon2i$v=19$m=1024,t=2,p=2$VEFSSU4wSzh3cllVdE1JZQ$PDeks/7JoKekQrJa9HlfkXIk8dAeZXOzUxLBwNFbZ44
  |
  |
  | For more information, check the password_hash function help: http://php.net/manual/en/function.password-hash.php

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -414,64 +414,6 @@ class Ion_auth
 	}
 
 	/**
-	 * @param int|string|array $check_group group(s) to check
-	 * @param int|string|bool  $id          user id
-	 * @param bool             $check_all   check if all groups is present, or any of the groups
-	 *
-	 * @return bool Whether the/all user(s) with the given ID(s) is/are in the given group
-	 * @author Phil Sturgeon
-	 **/
-	public function in_group($check_group, $id = FALSE, $check_all = FALSE)
-	{
-		$this->ion_auth_model->trigger_events('in_group');
-
-		$id || $id = $this->session->userdata('user_id');
-
-		if (!is_array($check_group))
-		{
-			$check_group = array($check_group);
-		}
-
-		if (isset($this->_cache_user_in_group[$id]))
-		{
-			$groups_array = $this->_cache_user_in_group[$id];
-		}
-		else
-		{
-			$users_groups = $this->ion_auth_model->get_users_groups($id)->result();
-			$groups_array = array();
-			foreach ($users_groups as $group)
-			{
-				$groups_array[$group->id] = $group->name;
-			}
-			$this->_cache_user_in_group[$id] = $groups_array;
-		}
-		foreach ($check_group as $key => $value)
-		{
-			$groups = (is_string($value)) ? $groups_array : array_keys($groups_array);
-
-			/**
-			 * if !all (default), in_array
-			 * if all, !in_array
-			 */
-			if (in_array($value, $groups) xor $check_all)
-			{
-				/**
-				 * if !all (default), true
-				 * if all, false
-				 */
-				return !$check_all;
-			}
-		}
-
-		/**
-		 * if !all (default), false
-		 * if all, true
-		 */
-		return $check_all;
-	}
-
-	/**
 	 * Check the compatibility with the server
 	 *
 	 * Script will die in case of error

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -236,12 +236,13 @@ class Ion_auth_model extends CI_Model
 	/**
 	 * Hashes the password to be stored in the database.
 	 *
+	 * @param string $identity
 	 * @param string $password
 	 *
 	 * @return false|string
 	 * @author Mathew
 	 */
-	public function hash_password($password)
+	public function hash_password($identity, $password)
 	{
 		// Check for empty password, or password containing null char
 		// Null char may pose issue: http://php.net/manual/en/function.password-hash.php#118603
@@ -250,20 +251,10 @@ class Ion_auth_model extends CI_Model
 			return FALSE;
 		}
 
-		if ($this->hash_method === 'bcrypt')
-		{
-			$algo = PASSWORD_BCRYPT;
-			$params = array(
-				'cost' => $this->config->item('bcrypt_default_cost', 'ion_auth')
-			);
-		}
-		else if ($this->hash_method === 'argon2')
-		{
-			$algo = PASSWORD_ARGON2I;
-			$params = $this->config->item('argon2_parameters', 'ion_auth');
-		}
+		$algo = $this->_get_hash_algo();
+		$params = $this->_get_hash_parameters($identity);
 
-		if (isset($algo) && isset($params))
+		if ($algo !== FALSE && $params !== FALSE)
 		{
 			return password_hash($password, $algo, $params);
 		}
@@ -328,20 +319,10 @@ class Ion_auth_model extends CI_Model
 	 */
 	public function rehash_password_if_needed($hash, $identity, $password)
 	{
-		if ($this->hash_method === 'bcrypt')
-		{
-			$algo = PASSWORD_BCRYPT;
-			$params = array(
-				'cost' => $this->config->item('bcrypt_default_cost', 'ion_auth')
-			);
-		}
-		else if ($this->hash_method === 'argon2')
-		{
-			$algo = PASSWORD_ARGON2I;
-			$params = $this->config->item('argon2_parameters', 'ion_auth');
-		}
+		$algo = $this->_get_hash_algo();
+		$params = $this->_get_hash_parameters($identity);
 
-		if (isset($algo) && isset($params))
+		if ($algo !== FALSE && $params !== FALSE)
 		{
 			if (password_needs_rehash($hash, $algo, $params))
 			{
@@ -656,6 +637,35 @@ class Ion_auth_model extends CI_Model
 	}
 
 	/**
+	 * Get user ID from identity
+	 *
+	 * @param $identity string
+	 *
+	 * @return bool|int
+	 */
+	public function get_user_id_from_identity($identity = '')
+	{
+		if (empty($identity))
+		{
+			return FALSE;
+		}
+
+		$query = $this->db->select('id')
+						  ->where($this->identity_column, $identity)
+						  ->limit(1)
+						  ->get($this->tables['users']);
+
+		if ($query->num_rows() !== 1)
+		{
+			return FALSE;
+		}
+
+		$user = $query->row();
+
+		return $user->id;
+	}
+
+	/**
 	 * Insert a forgotten password key.
 	 *
 	 * @param    string $identity
@@ -755,7 +765,7 @@ class Ion_auth_model extends CI_Model
 		// IP Address
 		$ip_address = $this->input->ip_address();
 
-		$password = $this->hash_password($password);
+		$password = $this->hash_password($identity, $password);
 
 		// Users table.
 		$data = array(
@@ -829,7 +839,7 @@ class Ion_auth_model extends CI_Model
 		if ($this->is_max_login_attempts_exceeded($identity))
 		{
 			// Hash something anyway, just to take up time
-			$this->hash_password($password);
+			$this->hash_password($identity, $password);
 
 			$this->trigger_events('post_login_unsuccessful');
 			$this->set_error('login_timeout');
@@ -878,7 +888,7 @@ class Ion_auth_model extends CI_Model
 		}
 
 		// Hash something anyway, just to take up time
-		$this->hash_password($password);
+		$this->hash_password($identity, $password);
 
 		$this->increase_login_attempts($identity);
 
@@ -1707,7 +1717,7 @@ class Ion_auth_model extends CI_Model
 			{
 				if( ! empty($data['password']))
 				{
-					$data['password'] = $this->hash_password($data['password']);
+					$data['password'] = $this->hash_password($user->{$this->identity_column}, $data['password']);
 				}
 				else
 				{
@@ -2400,7 +2410,7 @@ class Ion_auth_model extends CI_Model
 	 */
 	protected function _set_password_db($identity, $password)
 	{
-		$hash  = $this->hash_password($password);
+		$hash  = $this->hash_password($identity, $password);
 
 		// When setting a new password, invalidate any other token
 		$data = array(
@@ -2470,6 +2480,68 @@ class Ion_auth_model extends CI_Model
 
 		// No luck!
 		return FALSE;
+	}
+
+	/** Retrieve hash parameter according to options
+	 *
+	 * @param string	$identity
+	 *
+	 * @return array|bool
+	 */
+	protected function _get_hash_parameters($identity)
+	{
+		// Check if user is administrator or not
+		$is_admin = FALSE;
+		$user_id = $this->get_user_id_from_identity($identity);
+		if ($user_id && $this->in_group($this->config->item('admin_group', 'ion_auth'), $user_id))
+		{
+			$is_admin = TRUE;
+		}
+
+		$params = FALSE;
+		switch ($this->hash_method)
+		{
+			case 'bcrypt':
+				$params = array(
+					'cost' => $is_admin ? $this->config->item('bcrypt_admin_cost', 'ion_auth')
+										: $this->config->item('bcrypt_default_cost', 'ion_auth')
+				);
+				break;
+
+			case 'argon2':
+				$params = $is_admin ? $this->config->item('argon2_admin_params', 'ion_auth')
+									: $this->config->item('argon2_default_params', 'ion_auth');
+				break;
+
+			default:
+				// Do nothing
+		}
+
+		return $params;
+	}
+
+	/** Retrieve hash algorithm according to options
+	 *
+	 * @return string|bool
+	 */
+	protected function _get_hash_algo()
+	{
+		$algo = FALSE;
+		switch ($this->hash_method)
+		{
+			case 'bcrypt':
+				$algo = PASSWORD_BCRYPT;
+				break;
+
+			case 'argon2':
+				$algo = PASSWORD_ARGON2I;
+				break;
+
+			default:
+				// Do nothing
+		}
+
+		return $algo;
 	}
 
 	/**


### PR DESCRIPTION

See #1195 

The [bcrypt specs](https://www.usenix.org/legacy/publications/library/proceedings/usenix99/provos/provos_html/node6.html#SECTION00051000000000000000) suggests to have different costs for different type of account: 

> At the time of publication, the default cost is 6 for a normal user and 8 for the superuser.

The PR implements a new set of hashing parameters for users in admin group.

Note that the `in_group()` function was moved from the library to the model, so we can use it when retrieving parameters. 

Also, a `get_user_id_from_identity()` is introduced to be able to retrieve a user_id from an identity (and as such use it for group check).