### PR TITLE
Ion Auth 3: fix somes issues

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -234,6 +234,17 @@ class Ion_auth_model extends CI_Model
 	}
 
 	/**
+	 * Getter to the DB connection used by Ion Auth
+	 * May prove useful for debugging
+	 *
+	 * @return object
+	 */
+	public function db()
+	{
+		return $this->db;
+	}
+
+	/**
 	 * Hashes the password to be stored in the database.
 	 *
 	 * @param string $identity


### PR DESCRIPTION
#1195 

Add a getter for internal $db (for debugging purpose)

Rename `hash_password_db()` to `verify_password()` because the hashed password in DB can be pass by params.

Fix some issues