### PR TITLE
Ion Auth 3: always clear all codes when state change

### DIFF
--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -319,12 +319,14 @@ class Auth extends CI_Controller
 			}
 			else
 			{
+				$identity = $user->{$this->config->item('identity', 'ion_auth')};
+
 				// do we have a valid request?
 				if ($this->_valid_csrf_nonce() === FALSE || $user->id != $this->input->post('user_id'))
 				{
 
 					// something fishy might be up
-					$this->ion_auth->clear_forgotten_password_code($code);
+					$this->ion_auth->clear_forgotten_password_code($identity);
 
 					show_error($this->lang->line('error_csrf'));
 
@@ -332,8 +334,6 @@ class Auth extends CI_Controller
 				else
 				{
 					// finally change the password
-					$identity = $user->{$this->config->item('identity', 'ion_auth')};
-
 					$change = $this->ion_auth->reset_password($identity, $this->input->post('new'));
 
 					if ($change)

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -209,7 +209,8 @@ class Ion_auth
 				if (time() - $user->forgotten_password_time > $expiration)
 				{
 					//it has expired
-					$this->ion_auth_model->clear_forgotten_password_code($code);
+					$identity = $user->{$this->config->item('identity', 'ion_auth')};
+					$this->ion_auth_model->clear_forgotten_password_code($identity);
 					$this->set_error('password_change_unsuccessful');
 					return FALSE;
 				}
@@ -334,6 +335,10 @@ class Ion_auth
 
 		// delete the remember me cookies if they exist
 		delete_cookie($this->config->item('remember_cookie_name', 'ion_auth'));
+
+		// Clear all codes
+		$this->ion_auth_model->clear_forgotten_password_code($identity);
+		$this->ion_auth_model->clear_remember_code($identity);
 
 		// Destroy the session
 		$this->session->sess_destroy();


### PR DESCRIPTION

#1195 

`clear_forgotten_password_code()` now uses identity instead of code
Added `clear_remember_code()`

When the state change, we should be careful to clear all codes:
 - When user log in: clear forgotten code and remember me (if remember option not set)
 - When user automatically log in through remember me: clear forgotten code
 - When user log out: clear forgotten code and remember me
