### PR TITLE
Ion Auth 3: Various fixes

### DIFF
--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -34,7 +34,7 @@ class Auth extends CI_Controller
 		else if (!$this->ion_auth->is_admin()) // remove this elseif if you want to enable this for non-admins
 		{
 			// redirect them to the home page because they must be an administrator to view this
-			return show_error('You must be an administrator to view this page.');
+			show_error('You must be an administrator to view this page.');
 		}
 		else
 		{
@@ -399,7 +399,7 @@ class Auth extends CI_Controller
 		if (!$this->ion_auth->logged_in() || !$this->ion_auth->is_admin())
 		{
 			// redirect them to the home page because they must be an administrator to view this
-			return show_error('You must be an administrator to view this page.');
+			show_error('You must be an administrator to view this page.');
 		}
 
 		$id = (int)$id;
@@ -424,7 +424,7 @@ class Auth extends CI_Controller
 				// do we have a valid request?
 				if ($this->_valid_csrf_nonce() === FALSE || $id != $this->input->post('id'))
 				{
-					return show_error($this->lang->line('error_csrf'));
+					show_error($this->lang->line('error_csrf'));
 				}
 
 				// do we have the right userlevel?

--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -7,6 +7,7 @@
  */
 class Auth extends CI_Controller
 {
+	public $data = [];
 
 	public function __construct()
 	{
@@ -366,6 +367,8 @@ class Auth extends CI_Controller
 	 */
 	public function activate($id, $code = FALSE)
 	{
+		$activation = FALSE;
+
 		if ($code !== FALSE)
 		{
 			$activation = $this->ion_auth->activate($id, $code);
@@ -863,9 +866,9 @@ class Auth extends CI_Controller
 	public function _render_page($view, $data = NULL, $returnhtml = FALSE)//I think this makes more sense
 	{
 
-		$this->viewdata = (empty($data)) ? $this->data : $data;
+		$viewdata = (empty($data)) ? $this->data : $data;
 
-		$view_html = $this->load->view($view, $this->viewdata, $returnhtml);
+		$view_html = $this->load->view($view, $viewdata, $returnhtml);
 
 		// This will return html on 3rd argument being true
 		if ($returnhtml)

--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -113,7 +113,7 @@ class Auth extends CI_Controller
 		$this->data['title'] = "Logout";
 
 		// log the user out
-		$logout = $this->ion_auth->logout();
+		$this->ion_auth->logout();
 
 		// redirect them to the login page
 		$this->session->set_flashdata('message', $this->ion_auth->messages());

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -400,7 +400,7 @@ class Ion_auth
 
 		$admin_group = $this->config->item('admin_group', 'ion_auth');
 
-		return $this->in_group($admin_group, $id);
+		return $this->ion_auth_model->in_group($admin_group, $id);
 	}
 
 	/**

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -28,6 +28,11 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 class Ion_auth_model extends CI_Model
 {
 	/**
+	 * Max cookie lifetime constant
+	 */
+	const MAX_COOKIE_LIFETIME = 63072000; // 2 years = 60*60*24*365*2 = 63072000 seconds;
+
+	/**
 	 * Holds an array of tables used
 	 *
 	 * @var array
@@ -1858,7 +1863,7 @@ class Ion_auth_model extends CI_Model
 		// if the user_expire is set to zero we'll set the expiration two years from now.
 		if($this->config->item('user_expire', 'ion_auth') === 0)
 		{
-			$expire = 63072000; // 2 years = 60*60*24*365*2 = 63072000 seconds
+			$expire = self::MAX_COOKIE_LIFETIME;
 		}
 		// otherwise use what is set
 		else
@@ -1938,7 +1943,7 @@ class Ion_auth_model extends CI_Model
 				// if the user_expire is set to zero we'll set the expiration two years from now.
 				if($this->config->item('user_expire', 'ion_auth') === 0)
 				{
-					$expire = (60*60*24*365*2);
+					$expire = self::MAX_COOKIE_LIFETIME;
 				}
 				// otherwise use what is set
 				else

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -23,7 +23,6 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**
  * Class Ion Auth Model
- * @property Bcrypt $bcrypt The Bcrypt library
  * @property Ion_auth $ion_auth The Ion_auth library
  */
 class Ion_auth_model extends CI_Model
@@ -638,6 +637,8 @@ class Ion_auth_model extends CI_Model
 
 	/**
 	 * Identity check
+	 *
+	 * @param $identity string
 	 *
 	 * @return bool
 	 * @author Mathew

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -1495,7 +1495,7 @@ class Ion_auth_model extends CI_Model
 	 **/
 	public function in_group($check_group, $id = FALSE, $check_all = FALSE)
 	{
-		$this->ion_auth_model->trigger_events('in_group');
+		$this->trigger_events('in_group');
 
 		$id || $id = $this->session->userdata('user_id');
 


### PR DESCRIPTION
#1195 

Some (mostly cosmetic) fixes:
 - No show_error return value
 - Make sure some vars are defined before use (avoid hinting issue)
 - logout return value not used
 - in_group function fix
 - Comment hinting fix
 - Add MAX_COOKIE_LIFETIME constant to avoid multiple declaration
