### PR TITLE
Ion Auth 3: Removed max_password_length

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,6 +38,8 @@ The config file has changed:
     - `argon2_default_params` is added for the Argon2 hash method
     - `bcrypt_admin_cost` and `argon2_admin_params` are added to tweak the hash
     parameters for users in the admin group
+- For the **Authentication options** part:
+    - `max_password_length` is removed as it is not good practice to limit password's length
 - For the **Cookie options** part:
     - `random_identity_cookie_name` is removed as it doesn't serve any purpose anymore
 - The **Forgot Password Complete Email Template** part is completely removed because

--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -119,10 +119,13 @@ $config['argon2_admin_params']		= [
  | -------------------------------------------------------------------------
  | Authentication options.
  | -------------------------------------------------------------------------
- | maximum_login_attempts: This maximum is not enforced by the library, but is
- | used by $this->ion_auth->is_max_login_attempts_exceeded().
- | The controller should check this function and act
- | appropriately. If this variable set to 0, there is no maximum.
+ | maximum_login_attempts: 	This maximum is not enforced by the library, but is used by
+ | 							is_max_login_attempts_exceeded().
+ | 							The controller should check this function and act appropriately.
+ | 							If this variable set to 0, there is no maximum.
+ | min_password_length:		This minimum is not enforced directly by the library.
+ | 							The controller should define a validation rule to enforce it.
+ | 							See the Auth controller for an example implementation.
  */
 $config['site_title']                 = "Example.com";       // Site Title, example.com
 $config['admin_email']                = "admin@example.com"; // Admin Email, admin@example.com
@@ -132,8 +135,7 @@ $config['identity']                   = 'email';             /* You can use any 
 															    The values in this column, alongside password, will be used for login purposes
 															    IMPORTANT: If you are changing it from the default (email),
 															    		   update the UNIQUE constraint in your DB */
-$config['min_password_length']        = 8;                   // Minimum Required Length of Password
-$config['max_password_length']        = 20;                  // Maximum Allowed Length of Password
+$config['min_password_length']        = 8;                   // Minimum Required Length of Password (not enforced by lib - see note above)
 $config['email_activation']           = FALSE;               // Email Activation for registration
 $config['manual_activation']          = FALSE;               // Manual Activation for registration
 $config['remember_users']             = TRUE;                // Allow users to be remembered and enable auto-login

--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -129,7 +129,7 @@ class Auth extends CI_Controller
 	public function change_password()
 	{
 		$this->form_validation->set_rules('old', $this->lang->line('change_password_validation_old_password_label'), 'required');
-		$this->form_validation->set_rules('new', $this->lang->line('change_password_validation_new_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|max_length[' . $this->config->item('max_password_length', 'ion_auth') . ']|matches[new_confirm]');
+		$this->form_validation->set_rules('new', $this->lang->line('change_password_validation_new_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|matches[new_confirm]');
 		$this->form_validation->set_rules('new_confirm', $this->lang->line('change_password_validation_new_password_confirm_label'), 'required');
 
 		if (!$this->ion_auth->logged_in())
@@ -287,7 +287,7 @@ class Auth extends CI_Controller
 		{
 			// if the code is valid then display the password reset form
 
-			$this->form_validation->set_rules('new', $this->lang->line('reset_password_validation_new_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|max_length[' . $this->config->item('max_password_length', 'ion_auth') . ']|matches[new_confirm]');
+			$this->form_validation->set_rules('new', $this->lang->line('reset_password_validation_new_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|matches[new_confirm]');
 			$this->form_validation->set_rules('new_confirm', $this->lang->line('reset_password_validation_new_password_confirm_label'), 'required');
 
 			if ($this->form_validation->run() === FALSE)
@@ -476,7 +476,7 @@ class Auth extends CI_Controller
 		}
 		$this->form_validation->set_rules('phone', $this->lang->line('create_user_validation_phone_label'), 'trim');
 		$this->form_validation->set_rules('company', $this->lang->line('create_user_validation_company_label'), 'trim');
-		$this->form_validation->set_rules('password', $this->lang->line('create_user_validation_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|max_length[' . $this->config->item('max_password_length', 'ion_auth') . ']|matches[password_confirm]');
+		$this->form_validation->set_rules('password', $this->lang->line('create_user_validation_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|matches[password_confirm]');
 		$this->form_validation->set_rules('password_confirm', $this->lang->line('create_user_validation_password_confirm_label'), 'required');
 
 		if ($this->form_validation->run() === TRUE)
@@ -593,7 +593,7 @@ class Auth extends CI_Controller
 			// update the password if it was posted
 			if ($this->input->post('password'))
 			{
-				$this->form_validation->set_rules('password', $this->lang->line('edit_user_validation_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|max_length[' . $this->config->item('max_password_length', 'ion_auth') . ']|matches[password_confirm]');
+				$this->form_validation->set_rules('password', $this->lang->line('edit_user_validation_password_label'), 'required|min_length[' . $this->config->item('min_password_length', 'ion_auth') . ']|matches[password_confirm]');
 				$this->form_validation->set_rules('password_confirm', $this->lang->line('edit_user_validation_password_confirm_label'), 'required');
 			}
 


### PR DESCRIPTION
#1195 

As discussed, the max_password_length is removed and a note is added to remind that the min_password_length is not actually enforced by the library.