### PR TITLE
IonAuth 3: add max arbitrary size for password (DOS protection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Ion Auth Changelog
 
 ## xx March 2018 - Ion Auth 3
 
+ - **General:**
+    - No longer work for empty password or password above 4096 bytes (DOS protection)
  - **New server requirements:**
     - Drop CodeIgniter 2 support
     - Drop PHP < 5.6 support

--- a/config/ion_auth.php
+++ b/config/ion_auth.php
@@ -126,6 +126,9 @@ $config['argon2_admin_params']		= [
  | min_password_length:		This minimum is not enforced directly by the library.
  | 							The controller should define a validation rule to enforce it.
  | 							See the Auth controller for an example implementation.
+ |
+ | The library will fail for empty password or password size above 4096 bytes.
+ | This is an arbitrary (long) value to protect against DOS attack.
  */
 $config['site_title']                 = "Example.com";       // Site Title, example.com
 $config['admin_email']                = "admin@example.com"; // Admin Email, admin@example.com

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -32,10 +32,10 @@ class Ion_auth_model extends CI_Model
 	 */
 	const MAX_COOKIE_LIFETIME = 63072000; // 2 years = 60*60*24*365*2 = 63072000 seconds;
 
-    /**
-     * Max password size constant
-     */
-    const MAX_PASSWORD_SIZE_BYTES = 4096;
+	/**
+	 * Max password size constant
+	 */
+	const MAX_PASSWORD_SIZE_BYTES = 4096;
 
 	/**
 	 * Holds an array of tables used
@@ -266,9 +266,9 @@ class Ion_auth_model extends CI_Model
 	{
 		// Check for empty password, or password containing null char, or password above limit
 		// Null char may pose issue: http://php.net/manual/en/function.password-hash.php#118603
-        // Long password may pose DOS issue (note: strlen gives size in bytes and not in multibyte symbol)
+		// Long password may pose DOS issue (note: strlen gives size in bytes and not in multibyte symbol)
 		if (empty($password) || strpos($password, "\0") !== FALSE ||
-            strlen($password) > self::MAX_PASSWORD_SIZE_BYTES)
+			strlen($password) > self::MAX_PASSWORD_SIZE_BYTES)
 		{
 			return FALSE;
 		}
@@ -299,9 +299,9 @@ class Ion_auth_model extends CI_Model
 	{
 		// Check for empty id or password, or password containing null char, or password above limit
 		// Null char may pose issue: http://php.net/manual/en/function.password-hash.php#118603
-        // Long password may pose DOS issue (note: strlen gives size in bytes and not in multibyte symbol)
+		// Long password may pose DOS issue (note: strlen gives size in bytes and not in multibyte symbol)
 		if (empty($password) || empty($hash_password_db) || strpos($password, "\0") !== FALSE
-            || strlen($password) > self::MAX_PASSWORD_SIZE_BYTES)
+			|| strlen($password) > self::MAX_PASSWORD_SIZE_BYTES)
 		{
 			return FALSE;
 		}
@@ -816,11 +816,11 @@ class Ion_auth_model extends CI_Model
 		// Do not pass $identity as user is not known yet so there is no need
 		$password = $this->hash_password($password);
 
-        if ($password === FALSE)
-        {
-            $this->set_error('account_creation_unsuccessful');
-            return FALSE;
-        }
+		if ($password === FALSE)
+		{
+			$this->set_error('account_creation_unsuccessful');
+			return FALSE;
+		}
 
 		// Users table.
 		$data = [
@@ -1777,14 +1777,14 @@ class Ion_auth_model extends CI_Model
 				if( ! empty($data['password']))
 				{
 					$data['password'] = $this->hash_password($data['password'], $user->{$this->identity_column});
-                    if ($data['password'] === FALSE)
-                    {
-                        $this->db->trans_rollback();
-                        $this->trigger_events(['post_update_user', 'post_update_user_unsuccessful']);
-                        $this->set_error('update_unsuccessful');
+					if ($data['password'] === FALSE)
+					{
+						$this->db->trans_rollback();
+						$this->trigger_events(['post_update_user', 'post_update_user_unsuccessful']);
+						$this->set_error('update_unsuccessful');
 
-                        return FALSE;
-                    }
+						return FALSE;
+					}
 				}
 				else
 				{
@@ -2491,10 +2491,10 @@ class Ion_auth_model extends CI_Model
 	{
 		$hash = $this->hash_password($password, $identity);
 
-        if ($hash === FALSE)
-        {
-            return FALSE;
-        }
+		if ($hash === FALSE)
+		{
+			return FALSE;
+		}
 
 		// When setting a new password, invalidate any other token
 		$data = [

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -306,11 +306,12 @@ Documentation
         </li>
         <li>
             <strong>min_password_length</strong> Default is '8'<br/>
-            Minimum length of passwords.
-        </li>
-        <li>
-            <strong>max_password_length</strong> Default is '20'<br/>
-            Maximum length of passwords.
+            Minimum length of passwords.<br/>
+            This minimum is not enforced directly by the library.<br/>
+            The controller should define a validation rule to enforce it.<br/>
+            See the Auth controller for an example implementation.<br/><br/>
+            Additional note: the library will fail for empty password or password size above 4096 bytes.<br/>
+            This is an arbitrary (long) value to protect against DOS attack.
         </li>
         <li>
             <strong>email_activation</strong> Default is 'false'<br/>


### PR DESCRIPTION
Hello,

I'm back with a new PR :smile:

I came across [this article](https://arstechnica.com/information-technology/2013/09/long-passwords-are-good-but-too-much-length-can-be-bad-for-security/) which state that long password can be used as DOS attack vector. 

It was related to Django, the Python web framework:
>    Unfortunately, this complexity can also be used as an attack vector. Django does not impose any maximum on the length of the plaintext password, meaning that an attacker can simply submit arbitrarily large—and guaranteed-to-fail—passwords, forcing a server running Django to perform the resulting expensive hash computation in an attempt to check the password. A password one megabyte in size, for example, will require roughly one minute of computation to check when using the PBKDF2 hasher.
> This allows for denial-of-service attacks through repeated submission of large passwords, tying up server resources in the expensive computation of the corresponding hashes.

The solution the Django team used was to limit the max password length to an arbitrary number of 4096 bytes. I agree it is long enough, even for people using password managers.

Here is a PR adding this max size to limit DOS vector attack.

Also, I've added a check on every `hash_password()` return value to make sure a FALSE value isn't store in the DB.