### PR TITLE
Explains activation code

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -264,7 +264,7 @@ class Ion_auth
 				return FALSE;
 			}
 
-			// deactivate so the user much follow the activation flow
+			// deactivate so the user must follow the activation flow
 			$deactivate = $this->ion_auth_model->deactivate($id);
 
 			// the deactivate method call adds a message, here we need to clear that

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -46,7 +46,27 @@ class Ion_auth_model extends CI_Model
 
 	/**
 	 * activation code
-	 *
+	 * 
+	 * Set by deactivate() function
+	 * Also set on register() function, if email_activation 
+	 * option is activated
+	 * 
+	 * This is the value devs should give to the user 
+	 * (in an email, usually)
+	 * 
+	 * It contains the *user* version of the activation code
+	 * It's a value of the form "selector.validator" 
+	 * 
+	 * This is not the same activation_code as the one in DB.
+	 * The DB contains a *hashed* version of the validator
+	 * and a selector in another column.
+	 * 
+	 * THe selector is not private, and only used to lookup
+	 * the validator.
+	 * 
+	 * The validator is private, and to be only known by the user
+	 * So in case of DB leak, nothing could be actually used.
+	 * 
 	 * @var string
 	 */
 	public $activation_code;
@@ -2644,6 +2664,7 @@ class Ion_auth_model extends CI_Model
 
 	/**
 	 * Generate a random selector/validator couple
+	 * This is a user code
 	 *
 	 * @param $selector_size int	size of the selector token
 	 * @param $validator_size int	size of the validator token
@@ -2677,7 +2698,7 @@ class Ion_auth_model extends CI_Model
 	/**
 	 * Retrieve remember cookie info
 	 *
-	 * @param $user_code	string
+	 * @param $user_code string	A user code of the form "selector.validator"
 	 *
 	 * @return object
 	 * 			->selector		simple token to retrieve the user in DB

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -72,13 +72,6 @@ class Ion_auth_model extends CI_Model
 	public $activation_code;
 
 	/**
-	 * forgotten password key
-	 *
-	 * @var string
-	 */
-	public $forgotten_password_code;
-
-	/**
 	 * new password
 	 *
 	 * @var string


### PR DESCRIPTION
As discussed in #1271 

 - Added comment to explains better how `activation_code` works
 - Modify `activate()` function to extract the check activation code part, added as `check_user_code_activation()` function.
 - As a bonus, fix a bug in which event `post_activate_successful` would not be triggered if an activation code was provided
