### PR TITLE
Identity check should url decode

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -801,7 +801,7 @@ class Ion_auth_model extends CI_Model
 			return FALSE;
 		}
 
-		return $this->db->where($this->identity_column, $identity)
+		return $this->db->where($this->identity_column, urldecode($identity))
 						->limit(1)
 						->count_all_results($this->tables['users']) > 0;
 	}


### PR DESCRIPTION
... since the value stored in cookie is URL encoded.