### PR TITLE
 Remove extra backslash 

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -53,7 +53,7 @@ Don't forget to set Config\Migrations:enabled to true.
 
 You can also use the seeds file to insert default datas:
 ```
-$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder
+$ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder
 ```
 
 ---

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -53,7 +53,7 @@ Don't forget to set Config\Migrations:enabled to true.
 
 You can also use the seeds file to insert default datas:
 ```
-$ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder
+$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder
 ```
 
 ---

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -144,8 +144,8 @@ Documentation
 			<pre>$ php spark migrate:latest -n IonAuth</pre>
 		</li>
 		<li>
-			Insert default datas
-			<pre>$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder</pre>
+			Insert default datas (Don't forget to set Config\Migrations:enabled to true.)
+			<pre>$ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder</pre>
 		</li>
 	</ol>
 


### PR DESCRIPTION
double backslash '\\' is not needed when running in console to seed. php spark will not find the correct seeder class.