### PR TITLE
Spark seed - options for different OS

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -53,7 +53,7 @@ Don't forget to set Config\Migrations:enabled to true.
 
 You can also use the seeds file to insert default datas:
 ```
-$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder
+$ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder
 ```
 
 ---

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -53,7 +53,7 @@ Don't forget to set Config\Migrations:enabled to true.
 
 You can also use the seeds file to insert default datas:
 ```
-$ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder
+$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder
 ```
 
 ---

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -52,8 +52,13 @@ $ php spark migrate:latest -n IonAuth
 Don't forget to set Config\Migrations:enabled to true.
 
 You can also use the seeds file to insert default datas:
+Windows :
 ```
 $ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder
+```
+Linux :
+```
+$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder
 ```
 
 ---

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -145,7 +145,10 @@ Documentation
 		</li>
 		<li>
 			Insert default datas (Don't forget to set Config\Migrations:enabled to true.)
+			Windows :
 			<pre>$ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder</pre>
+			Linux :
+			<pre>$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder</pre>
 		</li>
 	</ol>
 

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -144,8 +144,8 @@ Documentation
 			<pre>$ php spark migrate:latest -n IonAuth</pre>
 		</li>
 		<li>
-			Insert default datas
-			<pre>$ php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder</pre>
+			Insert default datas (Don't forget to set Config\Migrations:enabled to true.)
+			<pre>$ php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder</pre>
 		</li>
 	</ol>
 


### PR DESCRIPTION
Windows user may encounter 'Class IonAuthSeeder not found' error when trying to execute spark seed command in console. My conclusion is that Linux OS use double backslash `\\` when traversing whereas Windows use only single backslash.

example :
`php spark db:seed IonAuth\Database\Seeds\IonAuthSeeder`
vs
`php spark db:seed IonAuth\\Database\\Seeds\\IonAuthSeeder`

@bvrignaud as Linux user.