### PR TITLE
German language file translation and fixes

### DIFF
--- a/language/german/auth_lang.php
+++ b/language/german/auth_lang.php
@@ -141,7 +141,7 @@ $lang['forgot_password_validation_email_label']  = 'Email';
 $lang['forgot_password_username_identity_label'] = 'Benutzername';
 $lang['forgot_password_email_identity_label']    = 'Email';
 $lang['forgot_password_email_not_found']         = 'Kein Eintrag für diese Email Adresse gefunden.';
-$lang['forgot_password_identity_not_found']      = 'Keine Eintrag für diesen Benutzernamen gefunden.';
+$lang['forgot_password_identity_not_found']      = 'Kein Eintrag für diesen Benutzernamen gefunden.';
 
 
 // Reset Password

--- a/language/german/auth_lang.php
+++ b/language/german/auth_lang.php
@@ -27,7 +27,7 @@ $lang['login_heading']         = 'Einloggen';
 $lang['login_subheading']      = 'Bitte loggen Sie sich ein mit Ihrer/n Email/Benutzernamen und Kennwort unten ein.';
 $lang['login_identity_label']  = 'Email/Benutzername:';
 $lang['login_password_label']  = 'Kennwort:';
-$lang['login_remember_label']  = 'Merken Sie mich:';
+$lang['login_remember_label']  = 'Eingeloggt bleiben:';
 $lang['login_submit_btn']      = 'Einloggen';
 $lang['login_forgot_password'] = 'Ihr Kennwort vergessen?';
 
@@ -52,7 +52,7 @@ $lang['deactivate_subheading']               = 'Sind Sie sicher dass Sie den Ben
 $lang['deactivate_confirm_y_label']          = 'Ja:';
 $lang['deactivate_confirm_n_label']          = 'Nein:';
 $lang['deactivate_submit_btn']               = 'Eingeben';
-$lang['deactivate_validation_confirm_label'] = 'bestätigung';
+$lang['deactivate_validation_confirm_label'] = 'Bestätigen';
 $lang['deactivate_validation_user_id_label'] = 'Benutzer ID';
 
 // Create User
@@ -134,14 +134,14 @@ $lang['change_password_validation_new_password_confirm_label'] = 'Neues Kennwort
 
 // Forgot Password
 $lang['forgot_password_heading']                 = 'Kennwort vergessen';
-$lang['forgot_password_subheading']              = 'Bitte geben Sie Ihre %s ein damit wir Ihnen eine Mail schicken können um das Kennwort zu ändern.';
+$lang['forgot_password_subheading']              = 'Bitte geben Sie Ihre %s ein damit wir Ihnen eine Email schicken können um das Kennwort zu ändern.';
 $lang['forgot_password_email_label']             = '%s:';
 $lang['forgot_password_submit_btn']              = 'Eingabe';
 $lang['forgot_password_validation_email_label']  = 'Email';
 $lang['forgot_password_username_identity_label'] = 'Benutzername';
 $lang['forgot_password_email_identity_label']    = 'Email';
-$lang['forgot_password_email_not_found']         = 'No record of that email address.';
-$lang['forgot_password_identity_not_found']         = 'No record of that username address.';
+$lang['forgot_password_email_not_found']         = 'Kein Eintrag für diese Email Adresse gefunden.';
+$lang['forgot_password_identity_not_found']      = 'Keine Eintrag für diesen Benutzernamen gefunden.';
 
 
 // Reset Password

--- a/language/german/ion_auth_lang.php
+++ b/language/german/ion_auth_lang.php
@@ -22,18 +22,18 @@
 // Account Creation
 $lang['account_creation_successful'] 	  	   = 'Das Benutzerkonto wurde erfolgreich erstellt';
 $lang['account_creation_unsuccessful'] 	     = 'Das Benutzerkonto konnte nicht erstellt werden';
-$lang['account_creation_duplicate_email']    = 'Die E-Mail-Adresse ist ungültig oder wird bereits verwendet';
+$lang['account_creation_duplicate_email']    = 'Die Email Adresse ist ungültig oder wird bereits verwendet';
 $lang['account_creation_duplicate_identity'] = 'Der Benutzername ist ungültig oder wird bereits verwendet';
 
 // TODO Please Translate
-$lang['account_creation_missing_default_group'] = 'Standard-Gruppe ist nicht gesetzt';
-$lang['account_creation_invalid_default_group'] = 'Ungültiger Standard-Gruppenname';
+$lang['account_creation_missing_default_group'] = 'Standard Gruppe ist nicht gesetzt';
+$lang['account_creation_invalid_default_group'] = 'Ungültiger Standard Gruppenname';
 
 
 // Password
 $lang['password_change_successful'] 	= 'Das Passwort wurde erfolgreich geändert';
 $lang['password_change_unsuccessful'] = 'Das Passwort konnte nicht geändert werden';
-$lang['forgot_password_successful'] 	= 'Es wurde eine E-Mail zum Zurücksetzen des Passwortes versandt';
+$lang['forgot_password_successful'] 	= 'Es wurde eine Email zum Zurücksetzen des Passwortes versandt';
 $lang['forgot_password_unsuccessful'] = 'Das Passwort konnte nicht zurückgesetzt werden';
 
 // Activation
@@ -41,9 +41,9 @@ $lang['activate_successful'] 		  	   = 'Das Benutzerkonto wurde aktiviert';
 $lang['activate_unsuccessful'] 		 	   = 'Das Benutzerkonto konnte nicht aktiviert werden';
 $lang['deactivate_successful'] 		  	 = 'Das Benutzerkonto wurde deaktiviert';
 $lang['deactivate_unsuccessful'] 	  	 = 'Das Benutzerkonto konnte nicht deaktiviert werden';
-$lang['activation_email_successful'] 	 = 'Es wurde eine E-Mail zum Aktivieren des Benutzerkontos versandt';
-$lang['activation_email_unsuccessful'] = 'Die Aktivierungs-E-Mail konnte nicht versandt werden';
-$lang['deactivate_current_user_unsuccessful']= 'You cannot De-Activate your self.';
+$lang['activation_email_successful'] 	 = 'Es wurde eine Email zum Aktivieren des Benutzerkontos versandt';
+$lang['activation_email_unsuccessful'] = 'Die Aktivierungsmail konnte nicht versandt werden';
+$lang['deactivate_current_user_unsuccessful']= 'Du kannst dich nicht selbst deaktivieren.';
 
 // Login / Logout
 $lang['login_successful'] 		  	     = 'Login erfolgreich';
@@ -64,9 +64,9 @@ $lang['group_already_exists']       = 'Gruppenname bereits vergeben';
 $lang['group_update_successful']    = 'Gruppendetails aktualisiert';
 $lang['group_delete_successful']    = 'Gruppe gelöscht';
 $lang['group_delete_unsuccessful'] 	= 'Gruppe konnte nicht gelöscht werden';
-$lang['group_delete_notallowed']    = 'Sie können die Administrator-Gruppe nicht löschen';
+$lang['group_delete_notallowed']    = 'Sie können die Administrator Gruppe nicht löschen';
 $lang['group_name_required'] 		    = '"Gruppenname" ist ein Pflichtfeld';
-$lang['group_name_admin_not_alter'] = 'Admin-Gruppenname kann nicht geändert werden';
+$lang['group_name_admin_not_alter'] = 'Admin Gruppenname kann nicht geändert werden';
 
 // Activation Email
 $lang['email_activation_subject']  = 'Aktivierung des Kontos';


### PR DESCRIPTION
**File: ion_auth_lang.php**

**Translation for:**
$lang['deactivate_current_user_unsuccessful']

**Fixes for:**
$lang['account_creation_duplicate_email']
$lang['account_creation_invalid_default_group']
$lang['forgot_password_successful']
$lang['activation_email_successful']
$lang['activation_email_unsuccessful']
$lang['group_delete_notallowed']
$lang['group_name_admin_not_alter']
$lang['account_creation_missing_default_group']


**File: auth_lang.php**

**Translation for:**
$lang['forgot_password_email_not_found']
$lang['forgot_password_identity_not_found']

**fixes for:**
$lang['login_remember_label']
$lang['deactivate_validation_confirm_label']
$lang['forgot_password_subheading']