### PR TITLE
Remove reference to ion_auth library inside ion_auth library for extending purposes

### DIFF
--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -265,7 +265,7 @@ class Ion_auth
 			}
 
 			// deactivate so the user must follow the activation flow
-			$deactivate = $this->ion_auth_model->deactivate($id);
+			$deactivate = $this->deactivate($id);
 
 			// the deactivate method call adds a message, here we need to clear that
 			$this->ion_auth_model->clear_messages();

--- a/libraries/Ion_auth.php
+++ b/libraries/Ion_auth.php
@@ -431,4 +431,22 @@ class Ion_auth
 		}
 	}
 
+	public function deactivate($id = NULL)
+	{
+		$this->trigger_events('deactivate');
+
+		if (!isset($id))
+		{
+			$this->set_error('deactivate_unsuccessful');
+			return FALSE;
+		}
+		else if ($this->logged_in() && $this->user()->row()->id == $id)
+		{
+			$this->set_error('deactivate_current_user_unsuccessful');
+			return FALSE;
+		}
+
+		return $this->ion_auth_model->deactivate($id);
+	}
+
 }

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -456,19 +456,6 @@ class Ion_auth_model extends CI_Model
 	 */
 	public function deactivate($id = NULL)
 	{
-		$this->trigger_events('deactivate');
-
-		if (!isset($id))
-		{
-			$this->set_error('deactivate_unsuccessful');
-			return FALSE;
-		}
-		else if ($this->ion_auth->logged_in() && $this->user()->row()->id == $id)
-		{
-			$this->set_error('deactivate_current_user_unsuccessful');
-			return FALSE;
-		}
-
 		$token = $this->_generate_selector_validator_couple(20, 40);
 		$this->activation_code = $token->user_code;
 


### PR DESCRIPTION
I need to extend Ion Auth, because I need to add some additional functionality (two-factor authentication and an additional database unique constraint check) to it for a project I'm working on, and I don't want to modify the original code.

So, I created my own library class `Authentication extends Ion_auth` and autoloaded (in `autoload.php`):
- the `third_party` folder I put `Ion_auth` in (under packages)
- my extension library class, `authentication` and **not** the `ion_auth` library (under libraries)

This works fine for most of Ion_auth's functions, except for `deactivate`, because that function requires that the original `ion_auth` library itself is loaded and not an extension of it, see `Ion_auth_model.php` line 466: `$this->ion_auth->logged_in()`.

If I autoload only my extension library, without autoloading the `ion_auth` library, this gives me an `Undefined property Auth::$ion_auth` error for the `deactivate` function. Autoloading both libraries fixes that, but loads two nearly identical objects in memory (the original and the extension), which in my opinion isn't ideal.

To fix this, I've moved the `logged_in()` check in the `deactivate` function from the `Ion_auth_model.php` file to the `Ion_auth.php` file, removing the dependency on the original library class by replacing `$this->ion_auth->logged_in()`, with `$this->logged_in()`.