### PR TITLE
Update 20181211100537_install_ion_auth.php

### DIFF
--- a/Database/Migrations/20181211100537_install_ion_auth.php
+++ b/Database/Migrations/20181211100537_install_ion_auth.php
@@ -177,7 +177,7 @@ class Migration_Install_ion_auth extends \CodeIgniter\Database\Migration
 			],
 		]);
 		$this->forge->addKey('id', true);
-		$this->forge->createTable($this->tables['users'], false, ['COLLATE' => 'utf8_general_ci']);
+		$this->forge->createTable($this->tables['users'], false);
 
 		// Drop table 'users_groups' if it exists
 		$this->forge->dropTable($this->tables['users_groups'], true);


### PR DESCRIPTION
Collate sequences on MySQL appear to be different to SQLite.
Edited to use the default collate sequences in both types of database system.