### PR TITLE
Do not query database with null identity in recheck_session

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -981,10 +981,10 @@ class Ion_auth_model extends CI_Model
 	 */
 	public function recheck_session()
 	{
-        if (empty($this->session->userdata('identity')))
-        {
-            return FALSE;
-        }
+		if (empty($this->session->userdata('identity')))
+		{
+			return FALSE;
+		}
 
 		$recheck = (NULL !== $this->config->item('recheck_timer', 'ion_auth')) ? $this->config->item('recheck_timer', 'ion_auth') : 0;
 

--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -981,6 +981,11 @@ class Ion_auth_model extends CI_Model
 	 */
 	public function recheck_session()
 	{
+        if (empty($this->session->userdata('identity')))
+        {
+            return FALSE;
+        }
+
 		$recheck = (NULL !== $this->config->item('recheck_timer', 'ion_auth')) ? $this->config->item('recheck_timer', 'ion_auth') : 0;
 
 		if ($recheck !== 0)


### PR DESCRIPTION
If user is not logged in when logged_in() method is called the following query is executed

```sql
SELECT `id`
FROM `users`
WHERE `email` IS NULL
AND `active` = '1'
ORDER BY `id` DESC
LIMIT 1 
```

This PR fixes the issue
