### PR TITLE
Fix a portuguese translation

### DIFF
--- a/language/portuguese/auth_lang.php
+++ b/language/portuguese/auth_lang.php
@@ -143,5 +143,5 @@ $lang['reset_password_heading']                               = 'Mudar Senha';
 $lang['reset_password_new_password_label']                    = 'Nova senha: (mínimo de %s caracteres)';
 $lang['reset_password_new_password_confirm_label']            = 'Confirme sua Nova Senha:';
 $lang['reset_password_submit_btn']                            = 'Mudar';
-$lang['reset_password_validation_new_password_label']         = 'Senha Antiga';
+$lang['reset_password_validation_new_password_label']         = 'Nova Senha';
 $lang['reset_password_validation_new_password_confirm_label'] = 'Confirme sua Nova Senha';


### PR DESCRIPTION
fix portuguese reset_password_validation_new_password_label

(was "Old Password" instead of "New Password")