### PR TITLE
fixed 'get_user_by_activation_code' function: check token

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -385,16 +385,19 @@ class Ion_auth_model extends CI_Model
 	{
 		// Retrieve the token object from the code
 		$token = $this->_retrieve_selector_validator_couple($user_code);
-	
-		// Retrieve the user according to this selector
-		$user = $this->where('activation_selector', $token->selector)->users()->row();
 
-		if ($user)
+		if ($token) 
 		{
-			// Check the hash against the validator
-			if ($this->verify_password($token->validator, $user->activation_code))
+			// Retrieve the user according to this selector
+			$user = $this->where('activation_selector', $token->selector)->users()->row();
+
+			if ($user)
 			{
-				return $user;
+				// Check the hash against the validator
+				if ($this->verify_password($token->validator, $user->activation_code))
+				{
+					return $user;
+				}
 			}
 		}
 


### PR DESCRIPTION
We need to check token because of it can be `FALSE`