### PR TITLE
one more place where  should be checked

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -773,15 +773,17 @@ class Ion_auth_model extends CI_Model
 		// Retrieve the token object from the code
 		$token = $this->_retrieve_selector_validator_couple($user_code);
 
-		// Retrieve the user according to this selector
-		$user = $this->where('forgotten_password_selector', $token->selector)->users()->row();
+		if($token) {
+			// Retrieve the user according to this selector
+			$user = $this->where('forgotten_password_selector', $token->selector)->users()->row();
 
-		if ($user)
-		{
-			// Check the hash against the validator
-			if ($this->verify_password($token->validator, $user->forgotten_password_code))
+			if ($user)
 			{
-				return $user;
+				// Check the hash against the validator
+				if ($this->verify_password($token->validator, $user->forgotten_password_code))
+				{
+					return $user;
+				}
 			}
 		}
 


### PR DESCRIPTION
Here token can also be `FALSE` in case when `$user_code` has no '.'. 