### PR TITLE
Add composer.json for 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "benedmunds/codeigniter-ion-auth",
+    "description": "Simple and Lightweight Auth System for CodeIgniter",
+    "type": "library",
+    "license": "MIT",
+    "homepage": "http://benedmunds.com/ion_auth",
+    "authors": [
+        {
+            "name": "Ben EDMUNDS"
+        }
+    ],
+    "require": {
+        "php": ">=5.6"
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:benedmunds/CodeIgniter-Ion-Auth.git"
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,26 @@
         }
     ],
     "scripts": {
-        "post-install-cmd": [
+        "install-ion-auth": [
+            "[ -f application/config/ion_auth.php ] || cp -p vendor/benedmunds/codeigniter-ion-auth/config/ion_auth.php application/config/",
+            "@install-ion-auth-clm",
+            "[ -d application/views/auth ] || cp -pr vendor/benedmunds/codeigniter-ion-auth/views/* application/views/"
+        ],
+        "force-install-ion-auth": [
             "cp -p vendor/benedmunds/codeigniter-ion-auth/config/ion_auth.php application/config/",
-            "cp -p vendor/benedmunds/codeigniter-ion-auth/controllers/Auth.php application/controllers/",
-            "cp -p vendor/benedmunds/codeigniter-ion-auth/libraries/Ion_auth.php application/libraries/",
-            "cp -p vendor/benedmunds/codeigniter-ion-auth/models/Ion_auth_model.php application/models/",
+            "@install-ion-auth-clm",
             "cp -pr vendor/benedmunds/codeigniter-ion-auth/views/* application/views/"
         ],
-        "post-update-cmd": [
+        "install-ion-auth-clm": [
             "cp -p vendor/benedmunds/codeigniter-ion-auth/controllers/Auth.php application/controllers/",
             "cp -p vendor/benedmunds/codeigniter-ion-auth/libraries/Ion_auth.php application/libraries/",
             "cp -p vendor/benedmunds/codeigniter-ion-auth/models/Ion_auth_model.php application/models/"
+        ],
+        "post-install-cmd": [
+            "@install-ion-auth"
+        ],
+        "post-update-cmd": [
+            "@install-ion-auth"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,19 @@
             "type": "vcs",
             "url": "git@github.com:benedmunds/CodeIgniter-Ion-Auth.git"
         }
-    ]
+    ],
+    "scripts": {
+        "post-install-cmd": [
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/config/ion_auth.php application/config/",
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/controllers/Auth.php application/controllers/",
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/libraries/Ion_auth.php application/libraries/",
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/models/Ion_auth_model.php application/models/",
+            "cp -pr vendor/benedmunds/codeigniter-ion-auth/views/* application/views/"
+        ],
+        "post-update-cmd": [
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/controllers/Auth.php application/controllers/",
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/libraries/Ion_auth.php application/libraries/",
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/models/Ion_auth_model.php application/models/"
+        ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,10 @@
     "scripts": {
         "install-ion-auth": [
             "[ -f application/config/ion_auth.php ] || cp -p vendor/benedmunds/codeigniter-ion-auth/config/ion_auth.php application/config/",
-            "@install-ion-auth-clm",
-            "[ -d application/views/auth ] || cp -pr vendor/benedmunds/codeigniter-ion-auth/views/* application/views/"
-        ],
-        "force-install-ion-auth": [
-            "cp -p vendor/benedmunds/codeigniter-ion-auth/config/ion_auth.php application/config/",
-            "@install-ion-auth-clm",
-            "cp -pr vendor/benedmunds/codeigniter-ion-auth/views/* application/views/"
-        ],
-        "install-ion-auth-clm": [
-            "cp -p vendor/benedmunds/codeigniter-ion-auth/controllers/Auth.php application/controllers/",
+            "[ -f application/controllers/Auth.php ] || cp -p vendor/benedmunds/codeigniter-ion-auth/controllers/Auth.php application/controllers/",
             "cp -p vendor/benedmunds/codeigniter-ion-auth/libraries/Ion_auth.php application/libraries/",
-            "cp -p vendor/benedmunds/codeigniter-ion-auth/models/Ion_auth_model.php application/models/"
+            "cp -p vendor/benedmunds/codeigniter-ion-auth/models/Ion_auth_model.php application/models/",
+            "[ -d application/views/auth ] || cp -pr vendor/benedmunds/codeigniter-ion-auth/views/* application/views/"
         ],
         "post-install-cmd": [
             "@install-ion-auth"


### PR DESCRIPTION
I just want to install the latest Ion Auth 3 with Composer like this:

```
$ composer require benedmunds/codeigniter-ion-auth:3.x-dev
```

But there is no `composer.json`, so I can't do it.
