### PR TITLE
unify varying German translation of password

### DIFF
--- a/language/arabic/auth_lang.php
+++ b/language/arabic/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/arabic/ion_auth_lang.php
+++ b/language/arabic/ion_auth_lang.php
@@ -5,7 +5,7 @@
 * Author: Emad Elsaid
 * 		  blazeeboy@gmail.com
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  30.08.2010
 *

--- a/language/bengali/auth_lang.php
+++ b/language/bengali/auth_lang.php
@@ -10,7 +10,7 @@
 * Author: Arifur Rahman
 *         @arif2009
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  25.03.2018
 *

--- a/language/bengali/ion_auth_lang.php
+++ b/language/bengali/ion_auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Arifur Rahman
 *         @arif2009
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.25.2018
 *

--- a/language/bulgarian/auth_lang.php
+++ b/language/bulgarian/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/bulgarian/ion_auth_lang.php
+++ b/language/bulgarian/ion_auth_lang.php
@@ -6,7 +6,7 @@
 * 		  ivan.kolev@gmail.com
 *
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  01.22.2013
 *

--- a/language/catalan/auth_lang.php
+++ b/language/catalan/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/catalan/ion_auth_lang.php
+++ b/language/catalan/ion_auth_lang.php
@@ -8,7 +8,7 @@
 *
 * Translation: Oriol Navascuez & duub qnnp
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  05.04.2010
 *

--- a/language/croatian/auth_lang.php
+++ b/language/croatian/auth_lang.php
@@ -12,7 +12,7 @@
 * Translation: primjeri
 *		info@primjeri.com
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/croatian/ion_auth_lang.php
+++ b/language/croatian/ion_auth_lang.php
@@ -9,7 +9,7 @@
 * Translation: primjeri
 *		info@primjeri.com
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.14.2010
 *

--- a/language/czech/auth_lang.php
+++ b/language/czech/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/danish/auth_lang.php
+++ b/language/danish/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         daniel@kyokodaniel.com
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  05.09.2013
 *

--- a/language/danish/ion_auth_lang.php
+++ b/language/danish/ion_auth_lang.php
@@ -4,7 +4,7 @@
 *
 * Author:
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:
 *

--- a/language/dutch/auth_lang.php
+++ b/language/dutch/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/english/auth_lang.php
+++ b/language/english/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/english/ion_auth_lang.php
+++ b/language/english/ion_auth_lang.php
@@ -6,7 +6,7 @@
 *         ben.edmunds@gmail.com
 *         @benedmunds
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.14.2010
 *

--- a/language/estonian/auth_lang.php
+++ b/language/estonian/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/estonian/ion_auth_lang.php
+++ b/language/estonian/ion_auth_lang.php
@@ -6,7 +6,7 @@
  *         esko@tsoon.com
  *         @eskolehtme
  *
- * Location: http://github.com/benedmunds/ion_auth/
+ * Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
  *
  * Created:  01.09.2011
  *

--- a/language/filipino/auth_lang.php
+++ b/language/filipino/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/filipino/ion_auth_lang.php
+++ b/language/filipino/ion_auth_lang.php
@@ -6,7 +6,7 @@
 *         ben.edmunds@gmail.com
 *         @benedmunds
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.14.2010
 *

--- a/language/finnish/auth_lang.php
+++ b/language/finnish/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/finnish/ion_auth_lang.php
+++ b/language/finnish/ion_auth_lang.php
@@ -6,7 +6,7 @@
 *         jarno.fabritius@meisso.com
 *         @meisso_jarno
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  01.03.2011
 *

--- a/language/french/auth_lang.php
+++ b/language/french/auth_lang.php
@@ -11,7 +11,7 @@
 *
 * Adjustments by ggallon
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  14.02.2014
 *

--- a/language/french/ion_auth_lang.php
+++ b/language/french/ion_auth_lang.php
@@ -8,7 +8,7 @@
 * Updated by: Gwenaël Gallon
 * 			  github@dev-ggallon
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.23.2010
 * Updated:  06.16.2017

--- a/language/german/auth_lang.php
+++ b/language/german/auth_lang.php
@@ -7,9 +7,9 @@
 *         @benedmunds
 *
 * Translation: Benjamin Neu (benny@duxu.de), Max Vogl mail@max-vogl.de
-*         
 *
-* Location: http://github.com/benedmunds/ion_auth/
+*
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  29.07.2013
 * Last-Edit: 23.04.2016

--- a/language/german/ion_auth_lang.php
+++ b/language/german/ion_auth_lang.php
@@ -9,7 +9,7 @@
 *
 *
 *
-* Location:     http://github.com/benedmunds/ion_auth/
+* Location:     https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  04.02.2010
 * Last-Edit: 23.04.2016

--- a/language/german/ion_auth_lang.php
+++ b/language/german/ion_auth_lang.php
@@ -5,14 +5,16 @@
 * Author:       Ben Edmunds
 * 		          ben.edmunds@gmail.com
 *               @benedmunds
-* Translation:  Bernd Hückstädt (akademie@joytopia.net), Benjamin Neu (benny@duxu.de), Max Vogl mail@max-vogl.de
-*
+* Translation:  Bernd Hückstädt (akademie@joytopia.net),
+*               Benjamin Neu (benny@duxu.de),
+*               Max Vogl (mail@max-vogl.de),
+*               Armin Stebich (ion_auth@mail.lordofbikes.de)
 *
 *
 * Location:     https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  04.02.2010
-* Last-Edit: 23.04.2016
+* Last-Edit: 13.11.2019
 *
 * Description:      German language file for Ion Auth messages and errors
 * Beschreibung:     Deutsche Sprach-Datei für Ion Auth System- und Fehlermeldungen
@@ -31,10 +33,10 @@ $lang['account_creation_invalid_default_group'] = 'Ungültiger Standard Gruppenn
 
 
 // Password
-$lang['password_change_successful']     = 'Das Passwort wurde erfolgreich geändert';
-$lang['password_change_unsuccessful']   = 'Das Passwort konnte nicht geändert werden';
-$lang['forgot_password_successful']     = 'Es wurde eine Email zum Zurücksetzen des Passwortes versandt';
-$lang['forgot_password_unsuccessful']   = 'Das Passwort konnte nicht zurückgesetzt werden';
+$lang['password_change_successful']     = 'Das Kennwort wurde erfolgreich geändert';
+$lang['password_change_unsuccessful']   = 'Das Kennwort konnte nicht geändert werden';
+$lang['forgot_password_successful']     = 'Es wurde eine Email zum Rücksetzen des Kennworts versandt';
+$lang['forgot_password_unsuccessful']   = 'Das Kennwort konnte nicht zurückgesetzt werden';
 
 // Activation
 $lang['activate_successful']                    = 'Das Benutzerkonto wurde aktiviert';
@@ -75,7 +77,7 @@ $lang['email_activate_subheading'] = 'Bitte klicken Sie auf diesen Link, um %s.'
 $lang['email_activate_link']       = 'Aktivieren Sie Ihr Benutzerkonto';
 
 // Forgot Password Email
-$lang['email_forgotten_password_subject'] = 'Vergessenes Kennwort Verifikation';
+$lang['email_forgotten_password_subject'] = 'Vergessenes Kennwort bestätigen';
 $lang['email_forgot_password_heading']    = 'Kennwort zurücksetzen für %s';
 $lang['email_forgot_password_subheading'] = 'Bitte klicken Sie auf diesen Link, um %s.';
 $lang['email_forgot_password_link']       = 'Ihr Kennwort zurückzusetzen';

--- a/language/german/ion_auth_lang.php
+++ b/language/german/ion_auth_lang.php
@@ -20,8 +20,8 @@
 */
 
 // Account Creation
-$lang['account_creation_successful'] 	  	   = 'Das Benutzerkonto wurde erfolgreich erstellt';
-$lang['account_creation_unsuccessful'] 	     = 'Das Benutzerkonto konnte nicht erstellt werden';
+$lang['account_creation_successful']         = 'Das Benutzerkonto wurde erfolgreich erstellt';
+$lang['account_creation_unsuccessful']       = 'Das Benutzerkonto konnte nicht erstellt werden';
 $lang['account_creation_duplicate_email']    = 'Die Email Adresse ist ungültig oder wird bereits verwendet';
 $lang['account_creation_duplicate_identity'] = 'Der Benutzername ist ungültig oder wird bereits verwendet';
 
@@ -31,31 +31,31 @@ $lang['account_creation_invalid_default_group'] = 'Ungültiger Standard Gruppenn
 
 
 // Password
-$lang['password_change_successful'] 	= 'Das Passwort wurde erfolgreich geändert';
-$lang['password_change_unsuccessful'] = 'Das Passwort konnte nicht geändert werden';
-$lang['forgot_password_successful'] 	= 'Es wurde eine Email zum Zurücksetzen des Passwortes versandt';
-$lang['forgot_password_unsuccessful'] = 'Das Passwort konnte nicht zurückgesetzt werden';
+$lang['password_change_successful']     = 'Das Passwort wurde erfolgreich geändert';
+$lang['password_change_unsuccessful']   = 'Das Passwort konnte nicht geändert werden';
+$lang['forgot_password_successful']     = 'Es wurde eine Email zum Zurücksetzen des Passwortes versandt';
+$lang['forgot_password_unsuccessful']   = 'Das Passwort konnte nicht zurückgesetzt werden';
 
 // Activation
-$lang['activate_successful'] 		  	   = 'Das Benutzerkonto wurde aktiviert';
-$lang['activate_unsuccessful'] 		 	   = 'Das Benutzerkonto konnte nicht aktiviert werden';
-$lang['deactivate_successful'] 		  	 = 'Das Benutzerkonto wurde deaktiviert';
-$lang['deactivate_unsuccessful'] 	  	 = 'Das Benutzerkonto konnte nicht deaktiviert werden';
-$lang['activation_email_successful'] 	 = 'Es wurde eine Email zum Aktivieren des Benutzerkontos versandt';
-$lang['activation_email_unsuccessful'] = 'Die Aktivierungsmail konnte nicht versandt werden';
-$lang['deactivate_current_user_unsuccessful']= 'Du kannst dich nicht selbst deaktivieren.';
+$lang['activate_successful']                    = 'Das Benutzerkonto wurde aktiviert';
+$lang['activate_unsuccessful']                  = 'Das Benutzerkonto konnte nicht aktiviert werden';
+$lang['deactivate_successful']                  = 'Das Benutzerkonto wurde deaktiviert';
+$lang['deactivate_unsuccessful']                = 'Das Benutzerkonto konnte nicht deaktiviert werden';
+$lang['activation_email_successful']            = 'Es wurde eine Email zum Aktivieren des Benutzerkontos versandt';
+$lang['activation_email_unsuccessful']          = 'Die Aktivierungsmail konnte nicht versandt werden';
+$lang['deactivate_current_user_unsuccessful']   = 'Du kannst dich nicht selbst deaktivieren.';
 
 // Login / Logout
-$lang['login_successful'] 		  	     = 'Login erfolgreich';
-$lang['login_unsuccessful'] 		       = 'Login fehlgeschlagen';
+$lang['login_successful']              = 'Login erfolgreich';
+$lang['login_unsuccessful']            = 'Login fehlgeschlagen';
 $lang['login_unsuccessful_not_active'] = 'Der Account ist deaktiviert';
 $lang['login_timeout']                 = 'Vorübergehend gesperrt. Versuchen Sie es später noch einmal.';
-$lang['logout_successful'] 		 	       = 'Logout erfolgreich';
+$lang['logout_successful']             = 'Logout erfolgreich';
 
 // Account Changes
-$lang['update_successful'] 	 = 'Die Konto-Informationen wurden erfolgreich geändert';
+$lang['update_successful']   = 'Die Konto-Informationen wurden erfolgreich geändert';
 $lang['update_unsuccessful'] = 'Die Konto-Informationen konnten nicht geändert werden';
-$lang['delete_successful'] 	 = 'Das Benutzerkonto wurde gelöscht';
+$lang['delete_successful']   = 'Das Benutzerkonto wurde gelöscht';
 $lang['delete_unsuccessful'] = 'Das Benutzerkonto konnte nicht gelöscht werden';
 
 // Groups
@@ -63,9 +63,9 @@ $lang['group_creation_successful']  = 'Gruppe wurde erfolgreich erstellt';
 $lang['group_already_exists']       = 'Gruppenname bereits vergeben';
 $lang['group_update_successful']    = 'Gruppendetails aktualisiert';
 $lang['group_delete_successful']    = 'Gruppe gelöscht';
-$lang['group_delete_unsuccessful'] 	= 'Gruppe konnte nicht gelöscht werden';
+$lang['group_delete_unsuccessful']  = 'Gruppe konnte nicht gelöscht werden';
 $lang['group_delete_notallowed']    = 'Sie können die Administrator Gruppe nicht löschen';
-$lang['group_name_required'] 		    = '"Gruppenname" ist ein Pflichtfeld';
+$lang['group_name_required']        = '"Gruppenname" ist ein Pflichtfeld';
 $lang['group_name_admin_not_alter'] = 'Admin Gruppenname kann nicht geändert werden';
 
 // Activation Email

--- a/language/greek/auth_lang.php
+++ b/language/greek/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/greek/ion_auth_lang.php
+++ b/language/greek/ion_auth_lang.php
@@ -5,7 +5,7 @@
 * Author: Vagelis Papaloukas
 * 		  vagelispapalou@yahoo.gr
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  02.04.2011
 *

--- a/language/hungarian/auth_lang.php
+++ b/language/hungarian/auth_lang.php
@@ -7,7 +7,7 @@
 *         @bosternakbalazs
 
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  07.19.2015
 *

--- a/language/hungarian/ion_auth_lang.php
+++ b/language/hungarian/ion_auth_lang.php
@@ -1,16 +1,16 @@
 <?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 /**
 * Name:  Ion Auth Lang - Hungarian
-* 
+*
 * Author: Balazs Bosternak
 * 		    b.bosternak@gmail.com
-* 
-* Location: http://github.com/benedmunds/ion_auth/
-*          
-* Created:  07.19.2015 
-* 
+*
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
+*
+* Created:  07.19.2015
+*
 * Description:  Hungarian language file for Ion Auth messages and errors
-* 
+*
 */
 
 // Account Creation

--- a/language/indonesian/auth_lang.php
+++ b/language/indonesian/auth_lang.php
@@ -9,7 +9,7 @@
 *
 *
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  21.06.2013
 * Last-Edit: 21.06.2017

--- a/language/italian/auth_lang.php
+++ b/language/italian/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/italian/ion_auth_lang.php
+++ b/language/italian/ion_auth_lang.php
@@ -6,7 +6,7 @@
 *         ben.edmunds@gmail.com
 *         @benedmunds
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  07.08.2010
 *

--- a/language/japanese/auth_lang.php
+++ b/language/japanese/auth_lang.php
@@ -9,7 +9,7 @@
 * Author/Translation: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.19.2013
 *

--- a/language/japanese/ion_auth_lang.php
+++ b/language/japanese/ion_auth_lang.php
@@ -12,7 +12,7 @@
 * Translation: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.14.2010
 *

--- a/language/korean/auth_lang.php
+++ b/language/korean/auth_lang.php
@@ -6,7 +6,7 @@
 * 		  sople1@snooey.net
 *         @sople1
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  2013-07-03
 *

--- a/language/korean/ion_auth_lang.php
+++ b/language/korean/ion_auth_lang.php
@@ -6,7 +6,7 @@
 * 		  sople1@snooey.net
 *         @sople1
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  2013-07-03
 *

--- a/language/lithuanian/auth_lang.php
+++ b/language/lithuanian/auth_lang.php
@@ -5,7 +5,7 @@
 * Translator: Donatas Glodenis
 * 		  dgvirtual@akl.lt
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  10.05.2016
 *

--- a/language/norwegian/auth_lang.php
+++ b/language/norwegian/auth_lang.php
@@ -13,7 +13,7 @@
 * 		  yngve.hoiseth@gmail.com
 *         @yhoiseth
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:   03.09.2013
 * Last-Edit: 16.11.2014

--- a/language/norwegian/ion_auth_lang.php
+++ b/language/norwegian/ion_auth_lang.php
@@ -10,7 +10,7 @@
 * 		  yngve.hoiseth@gmail.com
 *         @yhoiseth
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  01.01.2012
 * Last-Edit: 16.11.2014

--- a/language/persian/auth_lang.php
+++ b/language/persian/auth_lang.php
@@ -5,7 +5,7 @@
 * Author: pBeez
 *         @pbeez
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  01.01.2017
 *

--- a/language/persian/ion_auth_lang.php
+++ b/language/persian/ion_auth_lang.php
@@ -13,7 +13,7 @@
 * Modification: pBeez
 * 		  @pbeez
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  10.24.2012
 * Modified: 01.01.2017

--- a/language/pirate/auth_lang.php
+++ b/language/pirate/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/polish/auth_lang.php
+++ b/language/polish/auth_lang.php
@@ -9,7 +9,7 @@
 * Translation: Piotr Fuz
 *         piotr.fuz@gmail.com
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:    03.09.2013
 * Translated: 18.05.2017

--- a/language/polish/ion_auth_lang.php
+++ b/language/polish/ion_auth_lang.php
@@ -13,7 +13,7 @@
  *			vertisan@vrs-factory.pl
  *			@vertisan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.23.2010
 * Updated:  13.03.2016

--- a/language/portuguese/auth_lang.php
+++ b/language/portuguese/auth_lang.php
@@ -7,7 +7,7 @@
 *         @alphabraga
 *
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/romanian/auth_lang.php
+++ b/language/romanian/auth_lang.php
@@ -6,7 +6,7 @@
 * 		  avenir.ro@gmail.com
 *         @avenirer
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  10.09.2013
 *

--- a/language/romanian/ion_auth_lang.php
+++ b/language/romanian/ion_auth_lang.php
@@ -6,7 +6,7 @@
 * 		  avenir.ro@gmail.com
 *         @benedmunds
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  10.09.2013
 *

--- a/language/russian/auth_lang.php
+++ b/language/russian/auth_lang.php
@@ -12,7 +12,7 @@
  * Translation: Ievgen Sentiabov
  *         @joni-jones
  *
- * Location: http://github.com/benedmunds/ion_auth/
+ * Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
  *
  * Created:  03.09.2013
  *

--- a/language/russian/ion_auth_lang.php
+++ b/language/russian/ion_auth_lang.php
@@ -8,7 +8,7 @@
 * Translation:  Petrosyan R.
 *             for@petrosyan.rv.ua
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.26.2010
 *

--- a/language/slovak/auth_lang.php
+++ b/language/slovak/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Jakub Vatrt
 *         vatrtj@gmail.com
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  11.11.2016
 *

--- a/language/slovenian/auth_lang.php
+++ b/language/slovenian/auth_lang.php
@@ -4,10 +4,10 @@
 *
 * Author: Žiga Drnovšček
 * 		  ziga.drnovscek@gmail.com
-*         
 *
 *
-* Location: http://github.com/benedmunds/ion_auth/
+*
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  12.5.2013
 *

--- a/language/slovenian/ion_auth_lang.php
+++ b/language/slovenian/ion_auth_lang.php
@@ -7,7 +7,7 @@
 *
 *
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  12.5.2013
 *

--- a/language/spanish/auth_lang.php
+++ b/language/spanish/auth_lang.php
@@ -8,11 +8,11 @@
 *
 * Author: Daniel Davis
 *         @ourmaninjapan
-* 
+*
 * Author: Josue Ibarra
 *         @josuetijuana
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/spanish/ion_auth_lang.php
+++ b/language/spanish/ion_auth_lang.php
@@ -6,7 +6,7 @@
 *           contacto@wilfridogarcia.com
 *           @wilfridogarcia
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  05.04.2010
 *

--- a/language/swedish/auth_lang.php
+++ b/language/swedish/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/swedish/ion_auth_lang.php
+++ b/language/swedish/ion_auth_lang.php
@@ -6,7 +6,7 @@
 * 		  ben.edmunds@gmail.com
 *         @benedmunds
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.14.2010
 *

--- a/language/thai/auth_lang.php
+++ b/language/thai/auth_lang.php
@@ -12,7 +12,7 @@
 * 		  id513128@gmail.com
 *         @itpcc
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * created:  03.09.2013
 * modify :  10.11.2014

--- a/language/thai/ion_auth_lang.php
+++ b/language/thai/ion_auth_lang.php
@@ -10,7 +10,7 @@
 * 		  id513128@gmail.com
 *         @itpcc
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.14.2010
 * modify :  10.11.2014

--- a/language/ukrainian/auth_lang.php
+++ b/language/ukrainian/auth_lang.php
@@ -9,7 +9,7 @@
 * Author: Daniel Davis
 *         @ourmaninjapan
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/ukrainian/ion_auth_lang.php
+++ b/language/ukrainian/ion_auth_lang.php
@@ -8,7 +8,7 @@
 * Translation:  Petrosyan R.
 *             for@petrosyan.rv.ua
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.27.2010
 *

--- a/language/vietnamese/auth_lang.php
+++ b/language/vietnamese/auth_lang.php
@@ -6,7 +6,7 @@
 * 		  trungdq88@gmail.com
 *         @trungdq88
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  01.17.2015
 *

--- a/language/vietnamese/ion_auth_lang.php
+++ b/language/vietnamese/ion_auth_lang.php
@@ -6,7 +6,7 @@
 * 		  trungdq88@gmail.com
 *         @trungdq88
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  01.17.2015
 *

--- a/language/zh_cn/auth_lang.php
+++ b/language/zh_cn/auth_lang.php
@@ -12,7 +12,7 @@
 * Translation: Bruce Huang
 *         	   @libruce
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  03.09.2013
 *

--- a/language/zh_cn/ion_auth_lang.php
+++ b/language/zh_cn/ion_auth_lang.php
@@ -6,7 +6,7 @@
 * 		  Lkaihua@gmail.com
 *         @China
 *
-* Location: http://github.com/benedmunds/ion_auth/
+* Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
 *
 * Created:  10.24.2011
 *

--- a/language/zh_tw/auth_lang.php
+++ b/language/zh_tw/auth_lang.php
@@ -11,7 +11,7 @@ if (! defined('BASEPATH')) {
  *         appleboy.tw@gmail.com
  *         @taiwan
  *
- * Location: http://github.com/benedmunds/ion_auth/
+ * Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
  *
  * Created:  03.09.2013
  *

--- a/language/zh_tw/ion_auth_lang.php
+++ b/language/zh_tw/ion_auth_lang.php
@@ -11,7 +11,7 @@ if (! defined('BASEPATH')) {
  *         appleboy.tw@gmail.com
  *         @taiwan
  *
- * Location: http://github.com/benedmunds/ion_auth/
+ * Location: https://github.com/benedmunds/CodeIgniter-Ion-Auth
  *
  * Created:  03.14.2011
  *


### PR DESCRIPTION
When I want to fix the varying German translation of password, I recognized the broken github link in all language files and fixed this too.