### PR TITLE
remove reference to PHP >= 7.1 (CI4 do it for us)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple and lightweight authentication for your CodeIgniter apps.
 Note, this version is meant to be used with CodeIgniter 4 and is not backwards compatible with previous versions.  The database is backwards compatible though for those migrating from previous versions.
 
 ## Server requirements
-Ion Auth 4 needs **CodeIgniter 4** and **PHP 7.1**.
+Ion Auth 4 needs **CodeIgniter 4**.
 
 ## Documentation
 Documentation is located at http://benedmunds.com/ion_auth/

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,9 @@
         },
         {
             "name": "Benoit VRIGNAUD",
-            "email": "benoit.vrignaud@zaclys.net"
+            "email": "benoit.vrignaud@tangue.fr"
         }
     ],
-	"require": {
-		"php": ">=7.1",
-	},
 	"require-dev": {
         "phpunit/phpunit": "^7.3",
         "codeigniter4/codeigniter4-standard": "^1.0",


### PR DESCRIPTION
It look like there was a typo error in the composer.json file.
Maybe It will be better to install it with composer.