### PR TITLE
Update Auth.php

### DIFF
--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -744,28 +744,31 @@ class Auth extends CI_Controller
 				$this->session->set_flashdata('message', $this->ion_auth->messages());
 				redirect("auth", 'refresh');
 			}
+			else
+            		{
+				$this->session->set_flashdata('message', $this->ion_auth->errors());
+            		}			
 		}
-		else
-		{
-			// display the create group form
-			// set the flash data error message if there is one
-			$this->data['message'] = (validation_errors() ? validation_errors() : ($this->ion_auth->errors() ? $this->ion_auth->errors() : $this->session->flashdata('message')));
+			
+		// display the create group form
+		// set the flash data error message if there is one
+		$this->data['message'] = (validation_errors() ? validation_errors() : ($this->ion_auth->errors() ? $this->ion_auth->errors() : $this->session->flashdata('message')));
 
-			$this->data['group_name'] = [
-				'name'  => 'group_name',
-				'id'    => 'group_name',
-				'type'  => 'text',
-				'value' => $this->form_validation->set_value('group_name'),
-			];
-			$this->data['description'] = [
-				'name'  => 'description',
-				'id'    => 'description',
-				'type'  => 'text',
-				'value' => $this->form_validation->set_value('description'),
-			];
+		$this->data['group_name'] = [
+			'name'  => 'group_name',
+			'id'    => 'group_name',
+			'type'  => 'text',
+			'value' => $this->form_validation->set_value('group_name'),
+		];
+		$this->data['description'] = [
+			'name'  => 'description',
+			'id'    => 'description',
+			'type'  => 'text',
+			'value' => $this->form_validation->set_value('description'),
+		];
 
-			$this->_render_page('auth/create_group', $this->data);
-		}
+		$this->_render_page('auth/create_group', $this->data);
+		
 	}
 
 	/**
@@ -804,12 +807,12 @@ class Auth extends CI_Controller
 				if ($group_update)
 				{
 					$this->session->set_flashdata('message', $this->lang->line('edit_group_saved'));
+					redirect("auth", 'refresh');
 				}
 				else
 				{
 					$this->session->set_flashdata('message', $this->ion_auth->errors());
-				}
-				redirect("auth", 'refresh');
+				}				
 			}
 		}
 


### PR DESCRIPTION
Bugs descriped in issue https://github.com/benedmunds/CodeIgniter-Ion-Auth/issues/1397

**Proposed bug fixes**

**create_group**:
When `$new_group_id` is `FALSE` the error message(s) should be set and the create group form should be (re)displayed. Currently, a blank page is displayed if an error occurs since the `else` statements are never reached.

**edit_group**:
The user should be redirected to `auth`  only if the group update is successful otherwise any error message(s) should be displayed in the `edit_group` view.