### PR TITLE
Delete a buggy line in the register function of the ion auth model

### DIFF
--- a/models/Ion_auth_model.php
+++ b/models/Ion_auth_model.php
@@ -845,7 +845,6 @@ class Ion_auth_model extends CI_Model
 		// Users table.
 		$data = [
 			$this->identity_column => $identity,
-			'username' => $identity,
 			'password' => $password,
 			'email' => $email,
 			'ip_address' => $ip_address,


### PR DESCRIPTION
Let's say you want to register a user and the user should have a different email and username and the email is the identity.
This line of code, that I deleted, set the username equals to the identity and so equals to the email.
With deleting this line I prevented the described bug, but the user could use the username further as the identity.