### PR TITLE
Fixed email activation

### DIFF
--- a/Controllers/Auth.php
+++ b/Controllers/Auth.php
@@ -448,7 +448,7 @@ class Auth extends \CodeIgniter\Controller
 	{
 		$activation = false;
 
-		if (! $code)
+		if ($code)
 		{
 			$activation = $this->ionAuth->activate($id, $code);
 		}

--- a/Models/IonAuthModel.php
+++ b/Models/IonAuthModel.php
@@ -374,13 +374,13 @@ class IonAuthModel
 	 * Validates and removes activation code.
 	 *
 	 * @param integer|string $id   The user identifier
-	 * @param boolean        $code The *user* activation code
+	 * @param string         $code The *user* activation code
 	 *                             if omitted, simply activate the user without check
 	 *
 	 * @return boolean
 	 * @author Mathew
 	 */
-	public function activate($id, bool $code=false): bool
+	public function activate($id, $code=false): bool
 	{
 		$this->triggerEvents('pre_activate');
 
@@ -390,7 +390,7 @@ class IonAuthModel
 		}
 		// Activate if no code is given
 		// Or if a user was found with this code, and that it matches the id
-		if ($code === false || ($user && $user->id === $id))
+		if ($code === false || ($user && $user->id == $id))
 		{
 			$data = [
 				'activation_selector' => null,

--- a/Models/IonAuthModel.php
+++ b/Models/IonAuthModel.php
@@ -431,7 +431,7 @@ class IonAuthModel
 			$this->setError('IonAuth.deactivate_unsuccessful');
 			return false;
 		}
-		else if ((new \IonAuth\Libraries\IonAuth())->loggedIn() && $this->user()->row()->id === $id)
+		else if ((new \IonAuth\Libraries\IonAuth())->loggedIn() && $this->user()->row()->id == $id)
 		{
 			$this->setError('IonAuth.deactivate_current_user_unsuccessful');
 			return false;
@@ -907,7 +907,7 @@ class IonAuthModel
 		{
 			if ($this->verifyPassword($password, $user->password, $identity))
 			{
-				if ($user->active === 0)
+				if ($user->active == 0)
 				{
 					$this->triggerEvents('post_login_unsuccessful');
 					$this->setError('IonAuth.login_unsuccessful_not_active');

--- a/Models/IonAuthModel.php
+++ b/Models/IonAuthModel.php
@@ -380,17 +380,17 @@ class IonAuthModel
 	 * @return boolean
 	 * @author Mathew
 	 */
-	public function activate($id, $code=false): bool
+	public function activate($id, ?string $code=null): bool
 	{
 		$this->triggerEvents('pre_activate');
 
-		if ($code !== false)
+		if ($code)
 		{
 			$user = $this->getUserByActivationCode($code);
 		}
 		// Activate if no code is given
 		// Or if a user was found with this code, and that it matches the id
-		if ($code === false || ($user && $user->id == $id))
+		if (is_null($code) || ($user && $user->id == $id))
 		{
 			$data = [
 				'activation_selector' => null,

--- a/Models/IonAuthModel.php
+++ b/Models/IonAuthModel.php
@@ -384,7 +384,7 @@ class IonAuthModel
 	{
 		$this->triggerEvents('pre_activate');
 
-		if ($code)
+		if (!is_null($code))
 		{
 			$user = $this->getUserByActivationCode($code);
 		}

--- a/Models/IonAuthModel.php
+++ b/Models/IonAuthModel.php
@@ -380,17 +380,17 @@ class IonAuthModel
 	 * @return boolean
 	 * @author Mathew
 	 */
-	public function activate($id, ?string $code=null): bool
+	public function activate($id, string $code=''): bool
 	{
 		$this->triggerEvents('pre_activate');
 
-		if (!is_null($code))
+		if ($code)
 		{
 			$user = $this->getUserByActivationCode($code);
 		}
 		// Activate if no code is given
 		// Or if a user was found with this code, and that it matches the id
-		if (is_null($code) || ($user && $user->id == $id))
+		if (!$code || ($user && $user->id == $id))
 		{
 			$data = [
 				'activation_selector' => null,


### PR DESCRIPTION
In the Auth Controller I only removed a negation operator (the !).
Now it checks, if the $code string is empty to transfer the right parameter to the activate function.

In the Model I just changed 2 little things.
First I removed the bool datatype in the function head, that's let the function only accepts boolean.
I did that, because the function needs the code to work with and not just a boolean, whether the code is given or not.
Secondly I changed the comparative operator in a comparison from === to ==.
I don't know, if that's only a local problem, but on my system the $user->id variable is a string.
Because the $id variable is an int, the === operator return false.
If you changed this Operator, the comparison should work fine.