### PR TITLE
Only describe installing via Composer

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -4,7 +4,7 @@ Installing Ion Auth 4.x
 Before installing, please check that you are meeting the minimum server requirements.
 Ion Auth 4 needs CodeIgniter 4.x, PHP 7.1 and Composer.
 
-> With composer
+> For using the library, you should install with Composer
 
 For an existing composer project:
 ```shell
@@ -22,6 +22,15 @@ $ composer require benedmunds/CodeIgniter-Ion-Auth:4.x-dev
 ```
 ---
 
+> For developing against the library, you can use git directly
+```shell
+my-project$ git clone https://github.com/benedmunds/CodeIgniter-Ion-Auth.git
+my-project$ cd CodeIgniter-Ion-Auth
+CodeIgniter-Ion-Auth$ git checkout 4
+```
+Then in your Config/Autoload.php, add this :
+```php
+'IonAuth' => ROOTPATH . 'CodeIgniter-Ion-Auth',
 ```
 
 ---

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -2,12 +2,9 @@ Installing Ion Auth 4.x
 ===================================
 
 Before installing, please check that you are meeting the minimum server requirements.
-Ion Auth 4 needs CodeIgniter 4.x and PHP 7.1.
+Ion Auth 4 needs CodeIgniter 4.x, PHP 7.1 and Composer.
 
-There are different ways to install this package.
-
-
-> 1. With composer
+> With composer
 
 For an existing composer project:
 ```shell
@@ -25,32 +22,6 @@ $ composer require benedmunds/CodeIgniter-Ion-Auth:4.x-dev
 ```
 ---
 
-> 2. With Git:
-
-```shell
-my-project$ git clone https://github.com/benedmunds/CodeIgniter-Ion-Auth.git
-my-project$ cd CodeIgniter-Ion-Auth
-CodeIgniter-Ion-Auth$ git checkout 4
-```
-Then in your Config/Autoload.php, add this :
-```php
-'IonAuth' => ROOTPATH . 'CodeIgniter-Ion-Auth',
-```
-
----
-
-> 3. Download the archive, and move folder from this package to the root folder:
-
-```shell
-CI 4.x                           # → Root Directory
-├── app/
-├── ion-auth/               # → Ion-auth directory
-├── public
-├──...
-```
-Then in your Config/Autoload.php, add this :
-```php
-'IonAuth' => ROOTPATH . 'YOUR-ION_AUTH-FOLDER',
 ```
 
 ---


### PR DESCRIPTION
@bvrignaud I tend to agree with you, that all modern PHP apps should be using Composer.  So I'm proposing that we remove the other installing docs.  Thoughts?