### PR TITLE
Fixed italian translation for 'deactivate_subheading'

### DIFF
--- a/Language/it/Auth.php
+++ b/Language/it/Auth.php
@@ -47,7 +47,7 @@ return [
 
 	// Deactivate User
 	'deactivate_heading'                  => 'Disattiva Utente',
-	'deactivate_subheading'               => 'Sei sicuro di voler attivare l\'utente \'%s\'',
+	'deactivate_subheading'               => 'Sei sicuro di voler disattivare l\'utente \'%s\'',
 	'deactivate_confirm_y_label'          => 'S&igrave;:',
 	'deactivate_confirm_n_label'          => 'No:',
 	'deactivate_submit_btn'               => 'Invia',


### PR DESCRIPTION
Fixed the italian translation for 'deactivate_subheading' in Language/it/Auth.php