### PR TITLE
Fix for the "'IonAuth\Models\stdClass' not found" error while trying to install a hook

### DIFF
--- a/Models/IonAuthModel.php
+++ b/Models/IonAuthModel.php
@@ -2254,7 +2254,7 @@ class IonAuthModel
 	 */
 	public function setHook(string $event, string $name, string $class, string $method, array $arguments=[]): self
 	{
-		$this->ionHooks->{$event}[$name]            = new stdClass;
+		$this->ionHooks->{$event}[$name]            = new \stdClass;
 		$this->ionHooks->{$event}[$name]->class     = $class;
 		$this->ionHooks->{$event}[$name]->method    = $method;
 		$this->ionHooks->{$event}[$name]->arguments = $arguments;


### PR DESCRIPTION
Added '\' to stdClass instantiation in setHook() to fix the error