### PR TITLE
fix activation_code 

### DIFF
--- a/Libraries/IonAuth.php
+++ b/Libraries/IonAuth.php
@@ -252,7 +252,7 @@ class IonAuth
 				return false;
 			}
 
-			$activationCode = $this->ionAuthModel->activation_code;
+			$activationCode = $this->ionAuthModel->activationCode;
 			$identity       = $this->config->identity;
 			$user           = $this->ionAuthModel->user($id)->row();
 


### PR DESCRIPTION
Hi,
set `public $emailActivation          = true;               	// Email Activation for registration`
in Config/IonAuth.php file.
Then create a new user (auth/create_user).
Existence of an error after creating a new user.
Shouldn't it " activationCode "?