### PR TITLE
fix for composer

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -10,7 +10,7 @@ For an existing composer project:
 ```shell
 $ composer config minimum-stability dev
 $ composer config repositories.ionAuth vcs git@github.com:benedmunds/CodeIgniter-Ion-Auth.git
-$ composer require benedmunds/CodeIgniter-Ion-Auth:4.x-dev
+$ composer require benedmunds/codeigniter-ion-auth:4.x-dev
 ```
 
 For a new project:
@@ -18,7 +18,7 @@ For a new project:
 $ composer init
 $ composer config minimum-stability dev
 $ composer config repositories.ionAuth vcs git@github.com:benedmunds/CodeIgniter-Ion-Auth.git
-$ composer require benedmunds/CodeIgniter-Ion-Auth:4.x-dev
+$ composer require benedmunds/codeigniter-ion-auth:4.x-dev
 ```
 ---
 


### PR DESCRIPTION
Writing the branch with uppercase letters would end with a "[RuntimeException] require.benedmunds/CodeIgniter-Ion-Auth is invalid, it should not contain uppercase characters. Please use benedmunds/codeigniter-ion-auth instead." This should sovel the issue #1551