### PR TITLE
Add codeigniter framework version back to composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
             "email": "benoit.vrignaud@tangue.fr"
         }
     ],
+    "require": {
+	"codeigniter4/framework" : "^v4.3"
+    },
 	"require-dev": {
         "phpunit/phpunit": "^7.3",
         "codeigniter4/codeigniter4-standard": "^1.0",


### PR DESCRIPTION
In aba58c498d494f2d8e064e9fd85c4aba473c5e64 the reference to CodeIgniter was removed as it was in a dev version for a long while.

In the last 5 years however CI was released under the 4.x branch, so it seems apt to add it again.